### PR TITLE
simplify last, add init

### DIFF
--- a/src/church/lists.rs
+++ b/src/church/lists.rs
@@ -453,9 +453,10 @@ pub fn last() -> Term {
     app(
         z(),
         abs!(2, app!(
-            null(),
             Var(1),
-            abs(fls()),
+            abs!(5, Var(1)),
+            abs!(2, Var(2)),
+            abs!(3, Var(1)),
             abs(app!(
                 Var(2),
                 abs!(2, Var(1)),
@@ -463,6 +464,46 @@ pub fn last() -> Term {
                 abs!(2, Var(2)),
                 app(Var(2), abs!(2, Var(2))),
                 app(Var(3), app(Var(2), abs!(2, Var(1))))
+            )),
+            abs(Var(1))
+        ))
+    )
+}
+
+/// Applied to a Church-encoded list it returns the list without the last element.
+///
+/// INIT := Z (λzl.NULL l (λx.NIL) (λx.(NULL (FST l) NIL (PAIR (FST l) (z (SND l))))) I) =
+/// Z (λ λ NULL 1 (λ NIL) (λ (NULL (FST 2) NIL (PAIR (FST 2) (3 (SND 2))))) I)
+///
+/// # Example
+/// ```
+/// use lambda_calculus::church::lists::init;
+/// use lambda_calculus::*;
+///
+/// let list1 = Term::from(vec![0.into(), 1.into(), 2.into(), 3.into()]);
+/// let list2 = Term::from(vec![0.into(), 1.into(), 2.into()]);
+///
+/// assert_eq!(beta(app(init(), list1), NOR, 0, false), list2);
+/// ```
+pub fn init() -> Term {
+    app(
+        z(),
+        abs!(2, app!(
+            Var(1),
+            abs!(5, Var(1)),
+            abs!(2, Var(2)),
+            abs!(3, Var(1)),
+            abs(app!(
+                Var(2),
+                abs!(2, Var(1)),
+                abs!(5, Var(1)),
+                abs!(2, Var(2)),
+                abs!(2, Var(1)),
+                abs(app!(
+                    Var(1),
+                    app(Var(3), abs!(2, Var(2))),
+                    app(Var(4), app(Var(3), abs!(2, Var(1))))
+                ))
             )),
             abs(Var(1))
         ))

--- a/tests/church_lists.rs
+++ b/tests/church_lists.rs
@@ -22,3 +22,26 @@ fn test_last() {
     assert_eq!(beta(app(last(), list1()), HAP, 0, false), 1.into());
     assert_eq!(beta(app(last(), list2()), HAP, 0, false), 4.into());
 }
+
+#[test]
+fn test_init() {
+    let list1 = || { Term::from(vec![0.into(), 1.into(), 2.into(), 3.into(), 4.into()]) };
+    let list2 = || { Term::from(vec![0.into(), 1.into(), 2.into(), 3.into()]) };
+    let list3 = || { Term::from(vec![2.into(), 3.into()]) };
+    let list4 = || { Term::from(vec![2.into()]) };
+
+    assert_eq!(beta(app(init(), list1()), NOR, 0, false), list2());
+    assert_eq!(beta(app(init(), list3()), NOR, 0, false), list4());
+    assert_eq!(beta(app(init(), list4()), NOR, 0, false), nil());
+    assert_eq!(beta(app(init(), nil()), NOR, 0, false), nil());
+
+    assert_eq!(beta(app(init(), list1()), HNO, 0, false), list2());
+    assert_eq!(beta(app(init(), list3()), HNO, 0, false), list4());
+    assert_eq!(beta(app(init(), list4()), HNO, 0, false), nil());
+    assert_eq!(beta(app(init(), nil()), HNO, 0, false), nil());
+
+    assert_eq!(beta(app(init(), list1()), HAP, 0, false), list2());
+    assert_eq!(beta(app(init(), list3()), HAP, 0, false), list4());
+    assert_eq!(beta(app(init(), list4()), HAP, 0, false), nil());
+    assert_eq!(beta(app(init(), nil()), HAP, 0, false), nil());
+}


### PR DESCRIPTION
I wasn't sure about the best name for this function. I picked `init` because that's what it's called in the [Haskell Prelude](http://hackage.haskell.org/package/base-4.10.1.0/docs/Prelude.html#v:init), I'm open to suggestions though!