### PR TITLE
add outline of Church option type

### DIFF
--- a/benches/church_option.rs
+++ b/benches/church_option.rs
@@ -1,0 +1,27 @@
+#![cfg(not(feature = "no_church"))]
+
+#![feature(test)]
+extern crate test;
+
+#[macro_use]
+extern crate lambda_calculus as lambda;
+
+use test::Bencher;
+use lambda::reduction::*;
+use lambda::church::option::*;
+use lambda::church::numerals::succ;
+
+#[bench]
+fn option_is_none(b: &mut Bencher) {
+    b.iter(|| { beta(app!(is_none(), none()), HAP, 0, false) } );
+}
+
+#[bench]
+fn option_is_some(b: &mut Bencher) {
+    b.iter(|| { beta(app!(is_some(), none()), HAP, 0, false) } );
+}
+
+#[bench]
+fn option_map_or(b: &mut Bencher) {
+    b.iter(|| { beta(app!(map_or(), 0.into(), succ(), none()), HAP, 0, false) } );
+}

--- a/src/church/mod.rs
+++ b/src/church/mod.rs
@@ -6,3 +6,4 @@ pub mod numerals;
 pub mod booleans;
 pub mod pairs;
 pub mod lists;
+pub mod option;

--- a/src/church/option.rs
+++ b/src/church/option.rs
@@ -1,0 +1,87 @@
+//! Church-encoded option type with methods based on `std::Option`
+
+use term::{Term, abs, app};
+use term::Term::*;
+use church::booleans::{tru, fls};
+
+/// Produces a Church-encoded Option containing nothing.
+///
+/// NONE := λns.n = λ λ 2
+pub fn none() -> Term { tru() }
+
+/// Applied to an argument it produces a Church-encoded Option containing the argument.
+///
+/// SOME := λans.s a = λ λ λ 1 3
+///
+/// # Example
+/// ```
+/// use lambda_calculus::church::option::some;
+/// use lambda_calculus::*;
+///
+/// let some_one = app(some(), 1.into());
+/// ```
+pub fn some() -> Term {
+    abs!(3, app(Var(1), Var(3)))
+}
+
+/// Applied to a Church-encoded Option it produces a Church-encoded boolean indicating whether its
+/// argument is None.
+///
+/// IS_NONE := λa.a TRUE (λx.FALSE) = λ 1 TRUE (λ FALSE)
+///
+/// # Example
+/// ```
+/// use lambda_calculus::church::option::is_none;
+/// use lambda_calculus::*;
+///
+/// assert_eq!(beta(app(is_none(), None.into()), NOR, 0, false), true.into());
+/// assert_eq!(beta(app(is_none(), Some(1.into()).into()), NOR, 0, false), false.into());
+/// ```
+pub fn is_none() -> Term {
+    abs(app!(Var(1), tru(), abs(fls())))
+}
+
+/// Applied to a Church-encoded Option it produces a Church-encoded boolean indicating whether its
+/// argument is Some.
+///
+/// IS_SOME := λa.a FALSE (λx.TRUE) = λ 1 FALSE (λ TRUE)
+///
+/// # Example
+/// ```
+/// use lambda_calculus::church::option::is_some;
+/// use lambda_calculus::*;
+///
+/// assert_eq!(beta(app(is_some(), None.into()), NOR, 0, false), false.into());
+/// assert_eq!(beta(app(is_some(), Some(2.into()).into()), NOR, 0, false), true.into());
+/// ```
+pub fn is_some() -> Term {
+    abs(app!(Var(1), fls(), abs(tru())))
+}
+
+/// Applied to two arguments and a Church-encoded option, return second argument applied to the
+/// Church-encoded option if the option contains a value; otherwise, return the first argument.
+///
+/// MAP_OR := λdfm.m d f = λ λ λ 3 1 2
+///
+/// # Example
+/// ```
+/// use lambda_calculus::church::option::map_or;
+/// use lambda_calculus::church::numerals::succ;
+/// use lambda_calculus::*;
+///
+/// let some_one: Term = Some(1.into()).into();
+///
+/// assert_eq!(beta(app!(map_or(), 0.into(), succ(), some_one.clone()), NOR, 0, false), 2.into());
+/// ```
+pub fn map_or() -> Term {
+    abs!(3, app!(Var(1), Var(3), Var(2)))
+}
+
+impl From<Option<Term>> for Term {
+    fn from(option: Option<Term>) -> Self {
+        match option {
+            None => none(),
+            Some(value) => abs!(2, app(Var(1), value))
+        }
+    }
+}

--- a/tests/church_option.rs
+++ b/tests/church_option.rs
@@ -1,0 +1,66 @@
+#![cfg(not(feature = "no_church"))]
+
+extern crate lambda_calculus as lambda;
+
+use lambda::*;
+use lambda::church::option::*;
+use lambda::church::numerals::succ;
+
+#[test]
+fn test_none() {
+    assert_eq!(beta(None.into(), NOR, 0, false), none());
+    assert_eq!(beta(None.into(), HNO, 0, false), none());
+    assert_eq!(beta(None.into(), HAP, 0, false), none());
+}
+
+#[test]
+fn test_some() {
+    assert_eq!(
+        beta(Some(3.into()).into(), NOR, 0, false),
+        beta(app(some(), 3.into()), NOR, 0, false)
+    );
+    assert_eq!(
+        beta(Some(3.into()).into(), HNO, 0, false),
+        beta(app(some(), 3.into()), HNO, 0, false)
+    );
+    assert_eq!(
+        beta(Some(3.into()).into(), HAP, 0, false),
+        beta(app(some(), 3.into()), HAP, 0, false)
+    );
+}
+
+#[test]
+fn test_is_some() {
+    assert_eq!(beta(app(is_some(), None.into()), NOR, 0, false), false.into());
+    assert_eq!(beta(app(is_some(), Some(3.into()).into()), NOR, 0, false), true.into());
+
+    assert_eq!(beta(app(is_some(), None.into()), HNO, 0, false), false.into());
+    assert_eq!(beta(app(is_some(), Some(3.into()).into()), HNO, 0, false), true.into());
+
+    assert_eq!(beta(app(is_some(), None.into()), HAP, 0, false), false.into());
+    assert_eq!(beta(app(is_some(), Some(3.into()).into()), HAP, 0, false), true.into());
+}
+
+#[test]
+fn test_is_none() {
+    assert_eq!(beta(app(is_none(), None.into()), NOR, 0, false), true.into());
+    assert_eq!(beta(app(is_none(), Some(3.into()).into()), NOR, 0, false), false.into());
+
+    assert_eq!(beta(app(is_none(), None.into()), HNO, 0, false), true.into());
+    assert_eq!(beta(app(is_none(), Some(3.into()).into()), HNO, 0, false), false.into());
+
+    assert_eq!(beta(app(is_none(), None.into()), HAP, 0, false), true.into());
+    assert_eq!(beta(app(is_none(), Some(3.into()).into()), HAP, 0, false), false.into());
+}
+
+#[test]
+fn test_map_or() {
+    assert_eq!(beta(app!(map_or(), 5.into(), succ(), None.into()), NOR, 0, false), 5.into());
+    assert_eq!(beta(app!(map_or(), 5.into(), succ(), Some(1.into()).into()), NOR, 0, false), 2.into());
+
+    assert_eq!(beta(app!(map_or(), 5.into(), succ(), None.into()), HNO, 0, false), 5.into());
+    assert_eq!(beta(app!(map_or(), 5.into(), succ(), Some(1.into()).into()), HNO, 0, false), 2.into());
+
+    assert_eq!(beta(app!(map_or(), 5.into(), succ(), None.into()), HAP, 0, false), 5.into());
+    assert_eq!(beta(app!(map_or(), 5.into(), succ(), Some(1.into()).into()), HAP, 0, false), 2.into());
+}


### PR DESCRIPTION
Simple implementation of an option type encoded as functions. Feel free to reject if you believe this doesn't fit in with the rest of what's in the `church` module.

I didn't add anything to `impl Term`, I'm not sure what (if anything) should be added there for options.