### PR TITLE
add take and take_while for Church lists

### DIFF
--- a/benches/church_lists.rs
+++ b/benches/church_lists.rs
@@ -97,3 +97,13 @@ fn list_zip(b: &mut Bencher) {
 fn list_zip_with(b: &mut Bencher) {
     b.iter(|| { beta(app!(zip_with(), fls(), list3(), list3()), HAP, 0, false) } );
 }
+
+#[bench]
+fn list_take(b: &mut Bencher) {
+    b.iter(|| { beta(app!(take(), 2.into(), list3()), HAP, 0, false) } );
+}
+
+#[bench]
+fn list_zip_with(b: &mut Bencher) {
+    b.iter(|| { beta(app!(zip_with(), fls(), list3(), list3()), HAP, 0, false) } );
+}

--- a/benches/church_lists.rs
+++ b/benches/church_lists.rs
@@ -104,6 +104,6 @@ fn list_take(b: &mut Bencher) {
 }
 
 #[bench]
-fn list_zip_with(b: &mut Bencher) {
-    b.iter(|| { beta(app!(zip_with(), fls(), list3(), list3()), HAP, 0, false) } );
+fn list_take_while(b: &mut Bencher) {
+    b.iter(|| { beta(app!(take_while(), is_zero(), list3()), HAP, 0, false) } );
 }

--- a/src/church/lists.rs
+++ b/src/church/lists.rs
@@ -609,11 +609,11 @@ pub fn zip_with() -> Term {
     )
 }
 
-/// Applied to a Church-encoded number `n` and a Church-encoded list it returns the first `n`
-/// elements of the list.
+/// Applied to a Church-encoded number `n` and a Church-encoded list it returns a new list with the
+/// first `n` elements of the supplied list.
 ///
-/// TAKE := Z (λznl. NULL l (λx.NIL) (λx.IS_ZERO n NIL (CONS (HEAD l) (z (pred n) (TAIL l)))) I) =
-/// Z (λ λ λ NULL l (λ NIL) (λ (IS_ZERO n NIL (CONS (HEAD l) (z (pred n) (TAIL l))))) I)
+/// TAKE := Z (λznl. NULL l (λx.NIL) (λx.IS_ZERO n NIL (CONS (HEAD l) (z (PRED n) (TAIL l)))) I) =
+/// Z (λ λ λ NULL l (λ NIL) (λ (IS_ZERO n NIL (CONS (HEAD l) (z (PRED n) (TAIL l))))) I)
 ///
 /// # Example
 /// ```

--- a/src/church/lists.rs
+++ b/src/church/lists.rs
@@ -609,6 +609,94 @@ pub fn zip_with() -> Term {
     )
 }
 
+/// Applied to a Church-encoded number `n` and a Church-encoded list it returns the first `n`
+/// elements of the list.
+///
+/// TAKE := Z (λznl. NULL l (λx.NIL) (λx.IS_ZERO n NIL (CONS (HEAD l) (z (pred n) (TAIL l)))) I) =
+/// Z (λ λ λ NULL l (λ NIL) (λ (IS_ZERO n NIL (CONS (HEAD l) (z (pred n) (TAIL l))))) I)
+///
+/// # Example
+/// ```
+/// use lambda_calculus::church::lists::take;
+/// use lambda_calculus::*;
+///
+/// let list1 = Term::from(vec![0.into(), 1.into(), 2.into(), 3.into()]);
+/// let list2 = Term::from(vec![0.into(), 1.into()]);
+///
+/// assert_eq!(beta(app!(take(), 2.into(), list1), NOR, 0, false), list2);
+pub fn take() -> Term {
+    app(
+        z(),
+        abs!(3, app!(
+            Var(1),
+            abs!(5, Var(1)),
+            abs!(2, Var(2)),
+            abs!(3, Var(1)),
+            abs(app!(
+                Var(3),
+                abs!(3, Var(1)),
+                abs!(2, Var(2)),
+                abs!(2, Var(1)),
+                abs(app!(
+                    Var(1),
+                    app(Var(3), abs!(2, Var(2))),
+                    app!(
+                        Var(5),
+                        abs!(2, app!(
+                            Var(6),
+                            abs!(2, app(Var(1), app(Var(2), Var(4)))),
+                            abs(Var(2)),
+                            abs(Var(1))
+                        )),
+                        app(Var(3), abs!(2, Var(1)))
+                    )
+                ))
+            )),
+            abs(Var(1))
+        ))
+    )
+}
+
+/// Applied to a predicate function and a Church-encoded list it returns the longest prefix of the
+/// list whose elements all satisfy the predicate function.
+///
+/// TAKE_WHILE := Z (λzfl. NULL l (λx.NIL) (λx.f (HEAD l) (CONS (HEAD l) (z f (TAIL l))) NIL) I) =
+/// Z (λ λ λ NULL 1 (λ NIL) (λ 3 (HEAD 2) (CONS (HEAD 2) (4 3 (TAIL 2))) NIL) I)
+///
+/// # Example
+/// ```
+/// use lambda_calculus::church::lists::take_while;
+/// use lambda_calculus::church::numerals::is_zero;
+/// use lambda_calculus::*;
+///
+/// let list1 = Term::from(vec![0.into(), 0.into(), 1.into()]);
+/// let list2 = Term::from(vec![0.into(), 0.into()]);
+///
+/// assert_eq!(beta(app!(take_while(), is_zero(), list1), NOR, 0, false), list2);
+/// ```
+pub fn take_while() -> Term {
+    app(
+        z(),
+        abs!(3, app!(
+            Var(1),
+            abs!(5, Var(1)),
+            abs!(2, Var(1)),
+            abs!(3, Var(1)),
+            abs(app!(
+                Var(3),
+                app(Var(2), abs!(2, Var(2))),
+                abs(app!(
+                    Var(1),
+                    app(Var(3), abs!(2, Var(2))),
+                    app!(Var(5), Var(4), app(Var(3), abs!(2, Var(1))))
+                )),
+                abs!(2, Var(1))
+            )),
+            abs(Var(1))
+        ))
+    )
+}
+
 impl Term {
     /// Checks whether self is a empty Church list, i.e. `nil()`.
     ///

--- a/tests/church_lists.rs
+++ b/tests/church_lists.rs
@@ -4,7 +4,7 @@ extern crate lambda_calculus as lambda;
 
 use lambda::*;
 use lambda::church::lists::*;
-use lambda::church::numerals::plus;
+use lambda::church::numerals::{plus, is_zero};
 use lambda::church::booleans::fls;
 
 #[test]
@@ -75,4 +75,37 @@ fn test_zip_with() {
     assert_eq!(beta(app!(zip_with(), plus(), l1(), l4()), HAP, 0, false), l5());
     assert_eq!(beta(app!(zip_with(), fls(), l1(), l4()), HAP, 0, false), l2());
     assert_eq!(beta(app!(zip_with(), fls(), l4(), l1()), HAP, 0, false), l1());
+}
+
+#[test]
+fn test_take() {
+    let l1 = || { Term::from(vec![0.into()]) };
+    let l2 = || { Term::from(vec![0.into(), 1.into()]) };
+    let l3 = || { Term::from(vec![0.into(), 1.into(), 2.into()]) };
+    let l4 = || { Term::from(vec![0.into(), 1.into(), 2.into(), 3.into()]) };
+
+    assert_eq!(beta(app!(take(), 5.into(), l4()), HAP, 0, false), l4());
+    assert_eq!(beta(app!(take(), 4.into(), l4()), HAP, 0, false), l4());
+    assert_eq!(beta(app!(take(), 3.into(), l4()), HAP, 0, false), l3());
+    assert_eq!(beta(app!(take(), 2.into(), l4()), HAP, 0, false), l2());
+    assert_eq!(beta(app!(take(), 1.into(), l4()), HAP, 0, false), l1());
+    assert_eq!(beta(app!(take(), 0.into(), l4()), HAP, 0, false), nil());
+    assert_eq!(beta(app!(take(), 1.into(), l1()), HAP, 0, false), l1());
+    assert_eq!(beta(app!(take(), 0.into(), l1()), HAP, 0, false), nil());
+    assert_eq!(beta(app!(take(), 1.into(), nil()), HAP, 0, false), nil());
+}
+
+#[test]
+fn test_take_while() {
+    let l1 = || { Term::from(vec![0.into(), 0.into(), 2.into(), 3.into()]) };
+    let l2 = || { Term::from(vec![0.into(), 0.into()]) };
+    let l3 = || { Term::from(vec![1.into(), 4.into(), 2.into(), 3.into()]) };
+    let l4 = || { Term::from(vec![0.into(), 4.into(), 0.into(), 0.into()]) };
+    let l5 = || { Term::from(vec![0.into()]) };
+
+    assert_eq!(beta(app!(take_while(), is_zero(), nil()), HAP, 0, false), nil());
+    assert_eq!(beta(app!(take_while(), is_zero(), l1()), HAP, 0, false), l2());
+    assert_eq!(beta(app!(take_while(), is_zero(), l2()), HAP, 0, false), l2());
+    assert_eq!(beta(app!(take_while(), is_zero(), l3()), HAP, 0, false), nil());
+    assert_eq!(beta(app!(take_while(), is_zero(), l4()), HAP, 0, false), l5());
 }


### PR DESCRIPTION
Function names [from the Haskell Prelude](https://hackage.haskell.org/package/base-4.10.1.0/docs/Data-List.html#v:take).

This is a pretty naive implementation of `take()`, there may be a better variant that is able to avoid the use of `pred()`