### PR TITLE
add is_supercombinator to Term

### DIFF
--- a/benches/term.rs
+++ b/benches/term.rs
@@ -1,0 +1,22 @@
+#![feature(test)]
+extern crate test;
+
+#[macro_use]
+extern crate lambda_calculus as lambda;
+
+use test::Bencher;
+use lambda::term::*;
+
+#[bench]
+fn term_is_supercombinator(b: &mut Bencher) {
+    // Large arbitrary lambda term that is a supercombinator
+    let big_term = abs!(1000, app!(
+        abs!(1000, app!(abs(Var(10)), abs(Var(10)), abs(Var(10)))),
+        abs!(2000, app!(abs(Var(20)), abs(Var(20)), abs(Var(20)))),
+        abs!(3000, app!(abs(Var(30)), abs(Var(30)), abs(Var(30)))),
+        abs!(4000, app!(abs(Var(40)), abs(Var(40)), abs(Var(40)))),
+        abs!(5000, app!(abs(Var(50)), abs(Var(50)), abs(Var(50)))),
+        abs!(6000, app!(abs(Var(60)), abs(Var(60)), abs(Var(60))))
+    ));
+    b.iter(|| { assert_eq!(big_term.is_supercombinator(), true) });
+}

--- a/src/term.rs
+++ b/src/term.rs
@@ -289,14 +289,14 @@ impl Term {
         if let Ok((_, rhs)) = self.unapp_mut() { Ok(rhs) } else { Err(NotApp) }
     }
 
-    /// Returns `true` if and only if the lambda term is a
+    /// Returns `true` if the lambda term is a
     /// [supercombinator](https://en.wikipedia.org/wiki/Supercombinator).
     ///
     /// # Example
     /// ```
     /// use lambda_calculus::term::*;
     ///
-    /// let term1 = abs(app(Var(1), abs(Var(1)))); // λ 1 (λ 2)
+    /// let term1 = abs(app(Var(1), abs(Var(1)))); // λ 1 (λ 1)
     /// let term2 = app(abs(Var(2)), abs(Var(1))); // (λ 2) (λ 1)
     ///
     /// assert_eq!(term1.is_supercombinator(), true);
@@ -304,12 +304,12 @@ impl Term {
     /// ```
     pub fn is_supercombinator(&self) -> bool {
         let mut stack = Vec::new();
-        stack.push((0, self));
+        stack.push((0usize, self));
         while let Some((depth, term)) = stack.pop() {
-            match term {
-                &Term::Var(i) => if i > depth { return false },
-                &Term::Abs(ref t) => stack.push((depth + 1, t)),
-                &Term::App(ref f, ref a) => {
+            match *term {
+                Term::Var(i) => if i > depth { return false },
+                Term::Abs(ref t) => stack.push((depth + 1, t)),
+                Term::App(ref f, ref a) => {
                     stack.push((depth, f));
                     stack.push((depth, a))
                 }


### PR DESCRIPTION
Unrelated to 2.0.0 API changes, I think this is useful.

I wrote a naive recursive implementation for comparison; this naive iterative version is about 2x faster. Not sure if it's worth adding a warning to the documentation indicating that this function has to traverse the entire `Term`.