### PR TITLE
(WIP for 2.0.0) overhaul conversions to Term, refactor compile features

### DIFF
--- a/src/church/boolean.rs
+++ b/src/church/boolean.rs
@@ -2,6 +2,7 @@
 
 use term::{Term, abs};
 use term::Term::*;
+use church::conversions::IntoChurch;
 
 /// A Church-encoded boolean `true`.
 ///
@@ -155,15 +156,15 @@ pub fn nand() -> Term {
 /// use lambda_calculus::church::boolean::{if_else, tru, fls};
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(if_else(), tru(), 1.into(), 0.into()), NOR, 0), 1.into());
-/// assert_eq!(beta(app!(if_else(), fls(), 1.into(), 0.into()), NOR, 0), 0.into());
+/// assert_eq!(beta(app!(if_else(), tru(), tru(), fls()), NOR, 0), tru());
+/// assert_eq!(beta(app!(if_else(), fls(), tru(), fls()), NOR, 0), fls());
 /// ```
 pub fn if_else() -> Term {
     abs!(3, app!(Var(3), Var(2), Var(1)))
 }
 
-impl From<bool> for Term {
-    fn from(b: bool) -> Self {
-        if b { tru() } else { fls() }
+impl IntoChurch for bool {
+    fn into_church(self) -> Term {
+        if self { tru() } else { fls() }
     }
 }

--- a/src/church/conversions.rs
+++ b/src/church/conversions.rs
@@ -1,0 +1,17 @@
+//! Conversion to a Church-encoded `Term`
+
+use term::Term;
+
+/// Conversion to a Church-encoded lambda term
+pub trait IntoChurch {
+    /// Consume an object and return a Church-encoded `Term`
+    fn into_church(self) -> Term;
+}
+
+/// This impl can optionally not be built using `default-features = false`.
+#[cfg(feature = "church")]
+impl<T> From<T> for Term where T:IntoChurch {
+    fn from(t: T) -> Self {
+        t.into_church()
+    }
+}

--- a/src/church/list.rs
+++ b/src/church/list.rs
@@ -5,6 +5,7 @@ use term::Term::*;
 use church::boolean::{tru, fls};
 use church::pair::{pair, fst, snd};
 use church::numerals::zero;
+use church::conversions::IntoChurch;
 use combinators::Z;
 
 /// Equivalent to `booleans::fls()`; produces a Church-encoded `nil`, the last
@@ -22,7 +23,7 @@ pub fn nil() -> Term { fls() }
 /// use lambda_calculus::church::list::{nil, null};
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(null(), nil()), NOR, 0), true.into());
+/// assert_eq!(beta(app(null(), nil()), NOR, 0), true.into_church());
 /// ```
 pub fn null() -> Term {
     abs(app!(Var(1), abs!(3, fls()), tru()))
@@ -40,20 +41,20 @@ pub fn null() -> Term {
 /// let list_consed = beta(
 ///     app!(
 ///         cons(),
-///         1.into(),
+///         1.into_church(),
 ///         app!(
 ///             cons(),
-///             2.into(),
+///             2.into_church(),
 ///             app!(
 ///                 cons(),
-///                 3.into(),
+///                 3.into_church(),
 ///                 nil()
 ///             )
 ///         )
 ///     ), NOR, 0
 /// );
 ///
-/// let list_from_vec = Term::from(vec![1.into(), 2.into(), 3.into()]);
+/// let list_from_vec = vec![1, 2, 3].into_church();
 ///
 /// assert_eq!(list_consed, list_from_vec);
 /// ```
@@ -68,9 +69,9 @@ pub fn cons() -> Term { pair() }
 /// use lambda_calculus::church::list::head;
 /// use lambda_calculus::*;
 ///
-/// let list = Term::from(vec![1.into(), 2.into(), 3.into()]);
+/// let list = vec![1, 2, 3].into_church();
 ///
-/// assert_eq!(beta(app(head(), list), NOR, 0), 1.into());
+/// assert_eq!(beta(app(head(), list), NOR, 0), 1.into_church());
 /// ```
 pub fn head() -> Term { fst() }
 
@@ -84,11 +85,11 @@ pub fn head() -> Term { fst() }
 /// use lambda_calculus::church::list::tail;
 /// use lambda_calculus::*;
 ///
-/// let list = Term::from(vec![1.into(), 2.into(), 3.into()]);
+/// let list = vec![1, 2, 3].into_church();
 ///
 /// assert_eq!(
 ///     beta(app(tail(), list), NOR, 0),
-///     vec![2.into(), 3.into()].into()
+///     vec![2, 3].into_church()
 /// );
 /// ```
 pub fn tail() -> Term { snd() }
@@ -103,10 +104,10 @@ pub fn tail() -> Term { snd() }
 /// use lambda_calculus::church::list::{length, nil};
 /// use lambda_calculus::*;
 ///
-/// let list = Term::from(vec![1.into(), 2.into(), 3.into(), 4.into()]);
+/// let list = vec![1, 2, 3, 4].into_church();
 ///
-/// assert_eq!(beta(app(length(), nil()), NOR, 0), 0.into());
-/// assert_eq!(beta(app(length(), list ), NOR, 0), 4.into());
+/// assert_eq!(beta(app(length(), nil()), NOR, 0), 0.into_church());
+/// assert_eq!(beta(app(length(), list ), NOR, 0), 4.into_church());
 /// ```
 pub fn length() -> Term {
     app!(
@@ -137,11 +138,11 @@ pub fn length() -> Term {
 /// use lambda_calculus::church::list::reverse;
 /// use lambda_calculus::*;
 ///
-/// let list = Term::from(vec![1.into(), 2.into(), 3.into()]);
+/// let list = vec![1, 2, 3].into_church();
 ///
 /// assert_eq!(
 ///     beta(app(reverse(), list), NOR, 0),
-///     vec![3.into(), 2.into(), 1.into()].into()
+///     vec![3, 2, 1].into_church()
 /// );
 /// ```
 pub fn reverse() -> Term {
@@ -178,8 +179,8 @@ pub fn reverse() -> Term {
 /// use lambda_calculus::*;
 ///
 /// assert_eq!(
-///     beta(app!(list(), 3.into(), 1.into(), 2.into(), 3.into()), NOR, 0),
-///     vec![1.into(), 2.into(), 3.into()].into()
+///     beta(app!(list(), 3.into_church(), 1.into_church(), 2.into_church(), 3.into_church()), NOR, 0),
+///     vec![1, 2, 3].into_church()
 /// );
 /// ```
 pub fn list() -> Term {
@@ -201,12 +202,12 @@ pub fn list() -> Term {
 /// use lambda_calculus::church::list::append;
 /// use lambda_calculus::*;
 ///
-/// let list1 = Term::from(vec![1.into(), 2.into()]);
-/// let list2 = Term::from(vec![3.into(), 4.into()]);
+/// let list1 = vec![1, 2].into_church();
+/// let list2 = vec![3, 4].into_church();
 ///
 /// assert_eq!(
 ///     beta(app!(append(), list1, list2), NOR, 0),
-///     vec![1.into(), 2.into(), 3.into(), 4.into()].into()
+///     vec![1, 2, 3, 4].into_church()
 /// );
 /// ```
 pub fn append() -> Term {
@@ -240,10 +241,10 @@ pub fn append() -> Term {
 /// use lambda_calculus::church::list::index;
 /// use lambda_calculus::*;
 ///
-/// let list = Term::from(vec![1.into(), 2.into(), 3.into()]);
+/// let list = vec![1, 2, 3].into_church();
 ///
-/// assert_eq!(beta(app!(index(), 0.into(), list.clone()), NOR, 0), 1.into());
-/// assert_eq!(beta(app!(index(), 2.into(), list        ), NOR, 0), 3.into());
+/// assert_eq!(beta(app!(index(), 0.into_church(), list.clone()), NOR, 0), 1.into_church());
+/// assert_eq!(beta(app!(index(), 2.into_church(), list        ), NOR, 0), 3.into_church());
 /// ```
 pub fn index() -> Term {
     abs!(2, app!(
@@ -265,11 +266,11 @@ pub fn index() -> Term {
 /// use lambda_calculus::church::numerals::succ;
 /// use lambda_calculus::*;
 ///
-/// let list = Term::from(vec![1.into(), 2.into(), 3.into()]);
+/// let list = vec![1, 2, 3].into_church();
 ///
 /// assert_eq!(
 ///     beta(app!(map(), succ(), list), NOR, 0),
-///     vec![2.into(), 3.into(), 4.into()].into()
+///     vec![2, 3, 4].into_church()
 /// );
 /// ```
 pub fn map() -> Term {
@@ -309,10 +310,10 @@ pub fn map() -> Term {
 /// use lambda_calculus::church::numerals::plus;
 /// use lambda_calculus::*;
 ///
-/// let list = Term::from(vec![1.into(), 2.into(), 3.into()]);
+/// let list = vec![1, 2, 3].into_church();
 ///
-/// assert_eq!(beta(app!(foldl(), plus(), 0.into(), list ), NOR, 0), 6.into());
-/// assert_eq!(beta(app!(foldl(), plus(), 0.into(), nil()), NOR, 0), 0.into());
+/// assert_eq!(beta(app!(foldl(), plus(), 0.into_church(), list ), NOR, 0), 6.into_church());
+/// assert_eq!(beta(app!(foldl(), plus(), 0.into_church(), nil()), NOR, 0), 0.into_church());
 /// ```
 pub fn foldl() -> Term {
     Z().app(
@@ -349,10 +350,10 @@ pub fn foldl() -> Term {
 /// use lambda_calculus::church::numerals::plus;
 /// use lambda_calculus::*;
 ///
-/// let list = Term::from(vec![1.into(), 2.into(), 3.into()]);
+/// let list = vec![1, 2, 3].into_church();
 ///
-/// assert_eq!(beta(app!(foldr(), plus(), 0.into(), list ), NOR, 0), 6.into());
-/// assert_eq!(beta(app!(foldr(), plus(), 0.into(), nil()), NOR, 0), 0.into());
+/// assert_eq!(beta(app!(foldr(), plus(), 0.into_church(), list ), NOR, 0), 6.into_church());
+/// assert_eq!(beta(app!(foldr(), plus(), 0.into_church(), nil()), NOR, 0), 0.into_church());
 /// ```
 pub fn foldr() -> Term {
     abs!(3, app!(
@@ -385,16 +386,16 @@ pub fn foldr() -> Term {
 /// use lambda_calculus::combinators::C;
 /// use lambda_calculus::*;
 ///
-/// let list = Term::from(vec![0.into(), 1.into(), 2.into(), 3.into()]);
-/// let gt_1 = app!(C(), gt(), 1.into()); // greater than 1
+/// let list = vec![0, 1, 2, 3].into_church();
+/// let gt_1 = app!(C(), gt(), 1.into_church()); // greater than 1
 ///
 /// assert_eq!(
 ///     beta(app!(filter(), is_zero(), list.clone()), NOR, 0),
-///     vec![0.into()].into()
+///     vec![0].into_church()
 /// );
 /// assert_eq!(
 ///     beta(app!(filter(), gt_1, list), NOR, 0),
-///     vec![2.into(), 3.into()].into()
+///     vec![2, 3].into_church()
 /// );
 /// ```
 pub fn filter() -> Term {
@@ -434,9 +435,9 @@ pub fn filter() -> Term {
 /// use lambda_calculus::church::list::{last};
 /// use lambda_calculus::*;
 ///
-/// let list = Term::from(vec![0.into(), 1.into(), 2.into(), 3.into()]);
+/// let list = vec![0, 1, 2, 3].into_church();
 ///
-/// assert_eq!(beta(app(last(), list), NOR, 0), 3.into());
+/// assert_eq!(beta(app(last(), list), NOR, 0), 3.into_church());
 /// ```
 pub fn last() -> Term {
     app(
@@ -469,8 +470,8 @@ pub fn last() -> Term {
 /// use lambda_calculus::church::list::init;
 /// use lambda_calculus::*;
 ///
-/// let list1 = Term::from(vec![0.into(), 1.into(), 2.into(), 3.into()]);
-/// let list2 = Term::from(vec![0.into(), 1.into(), 2.into()]);
+/// let list1 = vec![0, 1, 2, 3].into_church();
+/// let list2 = vec![0, 1, 2].into_church();
 ///
 /// assert_eq!(beta(app(init(), list1), NOR, 0), list2);
 /// ```
@@ -510,8 +511,8 @@ pub fn init() -> Term {
 /// use lambda_calculus::church::list::zip;
 /// use lambda_calculus::*;
 ///
-/// let list1 = Term::from(vec![0.into(), 1.into()]);
-/// let pairs1 = Term::from(vec![(0.into(), 0.into()).into(), (1.into(), 1.into()).into()]);
+/// let list1 = vec![0, 1].into_church();
+/// let pairs1 = vec![(0, 0), (1, 1)].into_church();
 ///
 /// assert_eq!(beta(app!(zip(), list1.clone(), list1.clone()), NOR, 0), pairs1);
 /// ```
@@ -560,8 +561,8 @@ pub fn zip() -> Term {
 /// use lambda_calculus::church::numerals::plus;
 /// use lambda_calculus::*;
 ///
-/// let list1 = Term::from(vec![2.into(), 3.into()]);
-/// let list2 = Term::from(vec![4.into(), 6.into()]);
+/// let list1 = vec![2, 3].into_church();
+/// let list2 = vec![4, 6].into_church();
 ///
 /// assert_eq!(beta(app!(zip_with(), plus(), list1.clone(), list1), NOR, 0), list2);
 /// ```
@@ -609,10 +610,10 @@ pub fn zip_with() -> Term {
 /// use lambda_calculus::church::list::take;
 /// use lambda_calculus::*;
 ///
-/// let list1 = Term::from(vec![0.into(), 1.into(), 2.into(), 3.into()]);
-/// let list2 = Term::from(vec![0.into(), 1.into()]);
+/// let list1 = vec![0, 1, 2, 3].into_church();
+/// let list2 = vec![0, 1].into_church();
 ///
-/// assert_eq!(beta(app!(take(), 2.into(), list1), NOR, 0), list2);
+/// assert_eq!(beta(app!(take(), 2.into_church(), list1), NOR, 0), list2);
 pub fn take() -> Term {
     app(
         Z(),
@@ -658,8 +659,8 @@ pub fn take() -> Term {
 /// use lambda_calculus::church::numerals::is_zero;
 /// use lambda_calculus::*;
 ///
-/// let list1 = Term::from(vec![0.into(), 0.into(), 1.into()]);
-/// let list2 = Term::from(vec![0.into(), 0.into()]);
+/// let list1 = vec![0, 0, 1].into_church();
+/// let list2 = vec![0, 0].into_church();
 ///
 /// assert_eq!(beta(app!(take_while(), is_zero(), list1), NOR, 0), list2);
 /// ```
@@ -686,12 +687,24 @@ pub fn take_while() -> Term {
     )
 }
 
-impl From<Vec<Term>> for Term {
-    fn from(terms: Vec<Term>) -> Self {
+impl IntoChurch for Vec<Term> {
+    fn into_church(self) -> Term {
         let mut ret = nil();
 
-        for term in terms.into_iter().rev() {
+        for term in self.into_iter().rev() {
             ret = abs(app!(Var(1), term, ret))
+        }
+
+        ret
+    }
+}
+
+impl<T> IntoChurch for Vec<T> where T:IntoChurch {
+    fn into_church(self) -> Term {
+        let mut ret = nil();
+
+        for term in self.into_iter().rev() {
+            ret = abs(app!(Var(1), term.into_church(), ret))
         }
 
         ret

--- a/src/church/mod.rs
+++ b/src/church/mod.rs
@@ -1,6 +1,6 @@
 //! [Church-encoded](https://en.wikipedia.org/wiki/Church_encoding) data and operators
-//! This module can optionally not be built using `default-features = false`.
 
+pub mod conversions;
 pub mod numerals;
 pub mod boolean;
 pub mod pair;

--- a/src/church/numerals.rs
+++ b/src/church/numerals.rs
@@ -3,6 +3,7 @@
 use term::{Term, abs, app};
 use term::Term::*;
 use church::boolean::{tru, fls};
+use church::conversions::IntoChurch;
 use combinators::Z;
 
 /// Produces a Church-encoded number zero.
@@ -14,7 +15,7 @@ use combinators::Z;
 /// use lambda_calculus::church::numerals::zero;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(zero(), 0.into());
+/// assert_eq!(zero(), 0.into_church());
 /// ```
 pub fn zero() -> Term { abs!(2, Var(1)) }
 
@@ -28,8 +29,8 @@ pub fn zero() -> Term { abs!(2, Var(1)) }
 /// use lambda_calculus::church::numerals::is_zero;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(is_zero(), 0.into()), NOR, 0), true.into());
-/// assert_eq!(beta(app(is_zero(), 1.into()), NOR, 0), false.into());
+/// assert_eq!(beta(app(is_zero(), 0.into_church()), NOR, 0), true.into_church());
+/// assert_eq!(beta(app(is_zero(), 1.into_church()), NOR, 0), false.into_church());
 /// ```
 pub fn is_zero() -> Term {
     abs(app!(Var(1), abs(fls()), tru()))
@@ -44,7 +45,7 @@ pub fn is_zero() -> Term {
 /// use lambda_calculus::church::numerals::one;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(one(), 1.into());
+/// assert_eq!(one(), 1.into_church());
 /// ```
 pub fn one() -> Term {
     abs!(2, app(Var(2), Var(1)))
@@ -59,8 +60,8 @@ pub fn one() -> Term {
 /// use lambda_calculus::church::numerals::succ;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(succ(), 0.into()), NOR, 0), 1.into());
-/// assert_eq!(beta(app(succ(), 1.into()), NOR, 0), 2.into());
+/// assert_eq!(beta(app(succ(), 0.into_church()), NOR, 0), 1.into_church());
+/// assert_eq!(beta(app(succ(), 1.into_church()), NOR, 0), 2.into_church());
 /// ```
 pub fn succ() -> Term {
     abs!(3, app(Var(2), app!(Var(3), Var(2), Var(1))))
@@ -75,8 +76,8 @@ pub fn succ() -> Term {
 /// use lambda_calculus::church::numerals::plus;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(plus(), 1.into(), 2.into()), NOR, 0), 3.into());
-/// assert_eq!(beta(app!(plus(), 2.into(), 3.into()), NOR, 0), 5.into());
+/// assert_eq!(beta(app!(plus(), 1.into_church(), 2.into_church()), NOR, 0), 3.into_church());
+/// assert_eq!(beta(app!(plus(), 2.into_church(), 3.into_church()), NOR, 0), 5.into_church());
 /// ```
 pub fn plus() -> Term {
     abs!(4, app!(Var(4), Var(2), app!(Var(3), Var(2), Var(1))))
@@ -91,8 +92,8 @@ pub fn plus() -> Term {
 /// use lambda_calculus::church::numerals::mult;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(mult(), 1.into(), 2.into()), NOR, 0), 2.into());
-/// assert_eq!(beta(app!(mult(), 2.into(), 3.into()), NOR, 0), 6.into());
+/// assert_eq!(beta(app!(mult(), 1.into_church(), 2.into_church()), NOR, 0), 2.into_church());
+/// assert_eq!(beta(app!(mult(), 2.into_church(), 3.into_church()), NOR, 0), 6.into_church());
 /// ```
 pub fn mult() -> Term {
     abs!(3, app(Var(3), app(Var(2), Var(1))))
@@ -107,9 +108,9 @@ pub fn mult() -> Term {
 /// use lambda_calculus::church::numerals::pow;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(pow(), 3.into(), 0.into()), NOR, 0), 1.into());
-/// assert_eq!(beta(app!(pow(), 2.into(), 1.into()), NOR, 0), 2.into());
-/// assert_eq!(beta(app!(pow(), 2.into(), 3.into()), NOR, 0), 8.into());
+/// assert_eq!(beta(app!(pow(), 3.into_church(), 0.into_church()), NOR, 0), 1.into_church());
+/// assert_eq!(beta(app!(pow(), 2.into_church(), 1.into_church()), NOR, 0), 2.into_church());
+/// assert_eq!(beta(app!(pow(), 2.into_church(), 3.into_church()), NOR, 0), 8.into_church());
 /// ```
 pub fn pow() -> Term {
     abs!(2, app!(
@@ -130,8 +131,8 @@ pub fn pow() -> Term {
 /// use lambda_calculus::church::numerals::pred;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(pred(), 1.into()), NOR, 0), 0.into());
-/// assert_eq!(beta(app(pred(), 3.into()), NOR, 0), 2.into());
+/// assert_eq!(beta(app(pred(), 1.into_church()), NOR, 0), 0.into_church());
+/// assert_eq!(beta(app(pred(), 3.into_church()), NOR, 0), 2.into_church());
 /// ```
 pub fn pred() -> Term {
     abs!(3, app!(
@@ -151,9 +152,9 @@ pub fn pred() -> Term {
 /// use lambda_calculus::church::numerals::sub;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(sub(), 1.into(), 0.into()), NOR, 0), 1.into());
-/// assert_eq!(beta(app!(sub(), 3.into(), 1.into()), NOR, 0), 2.into());
-/// assert_eq!(beta(app!(sub(), 5.into(), 2.into()), NOR, 0), 3.into());
+/// assert_eq!(beta(app!(sub(), 1.into_church(), 0.into_church()), NOR, 0), 1.into_church());
+/// assert_eq!(beta(app!(sub(), 3.into_church(), 1.into_church()), NOR, 0), 2.into_church());
+/// assert_eq!(beta(app!(sub(), 5.into_church(), 2.into_church()), NOR, 0), 3.into_church());
 /// ```
 pub fn sub() -> Term {
     abs!(2, app!(Var(1), pred(), Var(2)))
@@ -169,10 +170,10 @@ pub fn sub() -> Term {
 /// use lambda_calculus::church::numerals::lt;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(lt(), 0.into(), 0.into()), NOR, 0), false.into());
-/// assert_eq!(beta(app!(lt(), 1.into(), 1.into()), NOR, 0), false.into());
-/// assert_eq!(beta(app!(lt(), 0.into(), 1.into()), NOR, 0), true.into());
-/// assert_eq!(beta(app!(lt(), 1.into(), 0.into()), NOR, 0), false.into());
+/// assert_eq!(beta(app!(lt(), 0.into_church(), 0.into_church()), NOR, 0), false.into_church());
+/// assert_eq!(beta(app!(lt(), 1.into_church(), 1.into_church()), NOR, 0), false.into_church());
+/// assert_eq!(beta(app!(lt(), 0.into_church(), 1.into_church()), NOR, 0), true.into_church());
+/// assert_eq!(beta(app!(lt(), 1.into_church(), 0.into_church()), NOR, 0), false.into_church());
 /// ```
 pub fn lt() -> Term {
     abs!(2, app!(
@@ -196,10 +197,10 @@ pub fn lt() -> Term {
 /// use lambda_calculus::church::numerals::leq;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(leq(), 0.into(), 0.into()), NOR, 0), true.into());
-/// assert_eq!(beta(app!(leq(), 1.into(), 1.into()), NOR, 0), true.into());
-/// assert_eq!(beta(app!(leq(), 0.into(), 1.into()), NOR, 0), true.into());
-/// assert_eq!(beta(app!(leq(), 1.into(), 0.into()), NOR, 0), false.into());
+/// assert_eq!(beta(app!(leq(), 0.into_church(), 0.into_church()), NOR, 0), true.into_church());
+/// assert_eq!(beta(app!(leq(), 1.into_church(), 1.into_church()), NOR, 0), true.into_church());
+/// assert_eq!(beta(app!(leq(), 0.into_church(), 1.into_church()), NOR, 0), true.into_church());
+/// assert_eq!(beta(app!(leq(), 1.into_church(), 0.into_church()), NOR, 0), false.into_church());
 /// ```
 pub fn leq() -> Term {
     abs!(2, app!(
@@ -221,10 +222,10 @@ pub fn leq() -> Term {
 /// use lambda_calculus::church::numerals::eq;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(eq(), 0.into(), 0.into()), NOR, 0), true.into());
-/// assert_eq!(beta(app!(eq(), 1.into(), 1.into()), NOR, 0), true.into());
-/// assert_eq!(beta(app!(eq(), 0.into(), 1.into()), NOR, 0), false.into());
-/// assert_eq!(beta(app!(eq(), 1.into(), 0.into()), NOR, 0), false.into());
+/// assert_eq!(beta(app!(eq(), 0.into_church(), 0.into_church()), NOR, 0), true.into_church());
+/// assert_eq!(beta(app!(eq(), 1.into_church(), 1.into_church()), NOR, 0), true.into_church());
+/// assert_eq!(beta(app!(eq(), 0.into_church(), 1.into_church()), NOR, 0), false.into_church());
+/// assert_eq!(beta(app!(eq(), 1.into_church(), 0.into_church()), NOR, 0), false.into_church());
 /// ```
 pub fn eq() -> Term {
     abs!(2, app!(
@@ -260,10 +261,10 @@ pub fn eq() -> Term {
 /// use lambda_calculus::church::numerals::neq;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(neq(), 0.into(), 0.into()), NOR, 0), false.into());
-/// assert_eq!(beta(app!(neq(), 1.into(), 1.into()), NOR, 0), false.into());
-/// assert_eq!(beta(app!(neq(), 0.into(), 1.into()), NOR, 0), true.into());
-/// assert_eq!(beta(app!(neq(), 1.into(), 0.into()), NOR, 0), true.into());
+/// assert_eq!(beta(app!(neq(), 0.into_church(), 0.into_church()), NOR, 0), false.into_church());
+/// assert_eq!(beta(app!(neq(), 1.into_church(), 1.into_church()), NOR, 0), false.into_church());
+/// assert_eq!(beta(app!(neq(), 0.into_church(), 1.into_church()), NOR, 0), true.into_church());
+/// assert_eq!(beta(app!(neq(), 1.into_church(), 0.into_church()), NOR, 0), true.into_church());
 /// ```
 pub fn neq() -> Term {
     abs!(2, app!(
@@ -305,10 +306,10 @@ pub fn neq() -> Term {
 /// use lambda_calculus::church::numerals::geq;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(geq(), 0.into(), 0.into()), NOR, 0), true.into());
-/// assert_eq!(beta(app!(geq(), 1.into(), 1.into()), NOR, 0), true.into());
-/// assert_eq!(beta(app!(geq(), 0.into(), 1.into()), NOR, 0), false.into());
-/// assert_eq!(beta(app!(geq(), 1.into(), 0.into()), NOR, 0), true.into());
+/// assert_eq!(beta(app!(geq(), 0.into_church(), 0.into_church()), NOR, 0), true.into_church());
+/// assert_eq!(beta(app!(geq(), 1.into_church(), 1.into_church()), NOR, 0), true.into_church());
+/// assert_eq!(beta(app!(geq(), 0.into_church(), 1.into_church()), NOR, 0), false.into_church());
+/// assert_eq!(beta(app!(geq(), 1.into_church(), 0.into_church()), NOR, 0), true.into_church());
 /// ```
 pub fn geq() -> Term {
     abs!(2, app!(
@@ -330,10 +331,10 @@ pub fn geq() -> Term {
 /// use lambda_calculus::church::numerals::gt;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(gt(), 0.into(), 0.into()), NOR, 0), false.into());
-/// assert_eq!(beta(app!(gt(), 1.into(), 1.into()), NOR, 0), false.into());
-/// assert_eq!(beta(app!(gt(), 0.into(), 1.into()), NOR, 0), false.into());
-/// assert_eq!(beta(app!(gt(), 1.into(), 0.into()), NOR, 0), true.into());
+/// assert_eq!(beta(app!(gt(), 0.into_church(), 0.into_church()), NOR, 0), false.into_church());
+/// assert_eq!(beta(app!(gt(), 1.into_church(), 1.into_church()), NOR, 0), false.into_church());
+/// assert_eq!(beta(app!(gt(), 0.into_church(), 1.into_church()), NOR, 0), false.into_church());
+/// assert_eq!(beta(app!(gt(), 1.into_church(), 0.into_church()), NOR, 0), true.into_church());
 /// ```
 pub fn gt() -> Term {
     abs!(2, app!(
@@ -359,12 +360,12 @@ pub fn gt() -> Term {
 /// use lambda_calculus::*;
 ///
 /// assert_eq!(
-///     beta(app!(div(), 4.into(), 2.into()), NOR, 0),
-///     (2.into(), 0.into()).into()
+///     beta(app!(div(), 4.into_church(), 2.into_church()), NOR, 0),
+///     (2, 0).into_church()
 /// );
 /// assert_eq!(
-///     beta(app!(div(), 5.into(), 3.into()), NOR, 0),
-///     (1.into(), 2.into()).into()
+///     beta(app!(div(), 5.into_church(), 3.into_church()), NOR, 0),
+///     (1, 2).into_church()
 /// );
 /// ```
 pub fn div() -> Term {
@@ -409,8 +410,8 @@ pub fn div() -> Term {
 /// use lambda_calculus::church::numerals::quot;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(quot(), 4.into(), 2.into()), NOR, 0), 2.into());
-/// assert_eq!(beta(app!(quot(), 5.into(), 3.into()), NOR, 0), 1.into());
+/// assert_eq!(beta(app!(quot(), 4.into_church(), 2.into_church()), NOR, 0), 2.into_church());
+/// assert_eq!(beta(app!(quot(), 5.into_church(), 3.into_church()), NOR, 0), 1.into_church());
 /// ```
 pub fn quot() -> Term {
     app(
@@ -453,8 +454,8 @@ pub fn quot() -> Term {
 /// use lambda_calculus::church::numerals::rem;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(rem(), 4.into(), 2.into()), NOR, 0), 0.into());
-/// assert_eq!(beta(app!(rem(), 5.into(), 3.into()), NOR, 0), 2.into());
+/// assert_eq!(beta(app!(rem(), 4.into_church(), 2.into_church()), NOR, 0), 0.into_church());
+/// assert_eq!(beta(app!(rem(), 5.into_church(), 3.into_church()), NOR, 0), 2.into_church());
 /// ```
 pub fn rem() -> Term {
     app(
@@ -492,8 +493,8 @@ pub fn rem() -> Term {
 /// use lambda_calculus::church::numerals::fac;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(fac(), 3.into()), NOR, 0), 6.into());
-/// assert_eq!(beta(app(fac(), 4.into()), NOR, 0), 24.into());
+/// assert_eq!(beta(app(fac(), 3.into_church()), NOR, 0), 6.into_church());
+/// assert_eq!(beta(app(fac(), 4.into_church()), NOR, 0), 24.into_church());
 /// ```
 pub fn fac() -> Term {
     abs(app!(
@@ -518,7 +519,7 @@ pub fn fac() -> Term {
 /// use lambda_calculus::church::numerals::min;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(min(), 4.into(), 3.into()), NOR, 0), 3.into());
+/// assert_eq!(beta(app!(min(), 4.into_church(), 3.into_church()), NOR, 0), 3.into_church());
 /// ```
 pub fn min() -> Term {
 	abs!(2, app!(
@@ -541,7 +542,7 @@ pub fn min() -> Term {
 /// use lambda_calculus::church::numerals::max;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(max(), 4.into(), 3.into()), NOR, 0), 4.into());
+/// assert_eq!(beta(app!(max(), 4.into_church(), 3.into_church()), NOR, 0), 4.into_church());
 /// ```
 pub fn max() -> Term {
 	abs!(2, app!(
@@ -565,9 +566,9 @@ pub fn max() -> Term {
 /// use lambda_calculus::church::numerals::lshift;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(lshift(), 0.into(), 2.into()), NOR, 0), 0.into());
-/// assert_eq!(beta(app!(lshift(), 1.into(), 0.into()), NOR, 0), 1.into());
-/// assert_eq!(beta(app!(lshift(), 2.into(), 0.into()), NOR, 0), 2.into());
+/// assert_eq!(beta(app!(lshift(), 0.into_church(), 2.into_church()), NOR, 0), 0.into_church());
+/// assert_eq!(beta(app!(lshift(), 1.into_church(), 0.into_church()), NOR, 0), 1.into_church());
+/// assert_eq!(beta(app!(lshift(), 2.into_church(), 0.into_church()), NOR, 0), 2.into_church());
 /// ```
 pub fn lshift() -> Term {
     abs!(3, app(
@@ -594,9 +595,9 @@ pub fn lshift() -> Term {
 /// use lambda_calculus::church::numerals::rshift;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(rshift(), 0.into(), 2.into()), NOR, 0), 0.into());
-/// assert_eq!(beta(app!(rshift(), 2.into(), 1.into()), NOR, 0), 1.into());
-/// assert_eq!(beta(app!(rshift(), 2.into(), 0.into()), NOR, 0), 2.into());
+/// assert_eq!(beta(app!(rshift(), 0.into_church(), 2.into_church()), NOR, 0), 0.into_church());
+/// assert_eq!(beta(app!(rshift(), 2.into_church(), 1.into_church()), NOR, 0), 1.into_church());
+/// assert_eq!(beta(app!(rshift(), 2.into_church(), 0.into_church()), NOR, 0), 2.into_church());
 /// ```
 pub fn rshift() -> Term {
     abs!(2, app!(
@@ -628,8 +629,8 @@ pub fn rshift() -> Term {
 /// use lambda_calculus::church::numerals::is_even;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(is_even(), 2.into()), NOR, 0), true.into());
-/// assert_eq!(beta(app(is_even(), 3.into()), NOR, 0), false.into());
+/// assert_eq!(beta(app(is_even(), 2.into_church()), NOR, 0), true.into_church());
+/// assert_eq!(beta(app(is_even(), 3.into_church()), NOR, 0), false.into_church());
 /// ```
 pub fn is_even() -> Term {
     abs(app!(Var(1), abs(app!(Var(1), fls(), tru())), tru()))
@@ -645,18 +646,18 @@ pub fn is_even() -> Term {
 /// use lambda_calculus::church::numerals::is_odd;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(is_odd(), 2.into()), NOR, 0), false.into());
-/// assert_eq!(beta(app(is_odd(), 3.into()), NOR, 0), true.into());
+/// assert_eq!(beta(app(is_odd(), 2.into_church()), NOR, 0), false.into_church());
+/// assert_eq!(beta(app(is_odd(), 3.into_church()), NOR, 0), true.into_church());
 /// ```
 pub fn is_odd() -> Term {
     abs(app!(Var(1), abs(app!(Var(1), fls(), tru())), fls()))
 }
 
-impl From<usize> for Term {
-    fn from(n: usize) -> Self {
+impl IntoChurch for usize {
+    fn into_church(self) -> Term {
         let mut ret = Var(1);
 
-        for _ in 0..n {
+        for _ in 0..self {
             ret = app(Var(2), ret);
         }
 

--- a/src/church/option.rs
+++ b/src/church/option.rs
@@ -3,6 +3,7 @@
 use term::{Term, abs, app};
 use term::Term::*;
 use church::boolean::{tru, fls};
+use church::conversions::IntoChurch;
 
 /// Produces a Church-encoded empty option.
 ///
@@ -18,7 +19,7 @@ pub fn none() -> Term { tru() }
 /// use lambda_calculus::church::option::some;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(some(), 1.into()), NOR, 0), Term::from(Some(1.into())));
+/// assert_eq!(beta(app(some(), 1.into_church()), NOR, 0), Some(1.into_church()).into_church());
 /// ```
 pub fn some() -> Term {
     abs!(3, app(Var(1), Var(3)))
@@ -34,8 +35,8 @@ pub fn some() -> Term {
 /// use lambda_calculus::church::option::is_none;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(is_none(), None.into()), NOR, 0), true.into());
-/// assert_eq!(beta(app(is_none(), Some(1.into()).into()), NOR, 0), false.into());
+/// assert_eq!(beta(app(is_none(), None.into_church()), NOR, 0), true.into_church());
+/// assert_eq!(beta(app(is_none(), Some(1.into_church()).into_church()), NOR, 0), false.into_church());
 /// ```
 pub fn is_none() -> Term {
     abs(app!(Var(1), tru(), abs(fls())))
@@ -51,8 +52,8 @@ pub fn is_none() -> Term {
 /// use lambda_calculus::church::option::is_some;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(is_some(), None.into()), NOR, 0), false.into());
-/// assert_eq!(beta(app(is_some(), Some(2.into()).into()), NOR, 0), true.into());
+/// assert_eq!(beta(app(is_some(), None.into_church()), NOR, 0), false.into_church());
+/// assert_eq!(beta(app(is_some(), Some(2.into_church()).into_church()), NOR, 0), true.into_church());
 /// ```
 pub fn is_some() -> Term {
     abs(app!(Var(1), fls(), abs(tru())))
@@ -69,17 +70,17 @@ pub fn is_some() -> Term {
 /// use lambda_calculus::church::numerals::succ;
 /// use lambda_calculus::*;
 ///
-/// let some_one: Term = Some(1.into()).into();
+/// let some_one: Term = Some(1.into_church()).into_church();
 ///
-/// assert_eq!(beta(app!(map_or(), 0.into(), succ(), some_one), NOR, 0), 2.into());
+/// assert_eq!(beta(app!(map_or(), 0.into_church(), succ(), some_one), NOR, 0), 2.into_church());
 /// ```
 pub fn map_or() -> Term {
     abs!(3, app!(Var(1), Var(3), Var(2)))
 }
 
-impl From<Option<Term>> for Term {
-    fn from(option: Option<Term>) -> Self {
-        match option {
+impl IntoChurch for Option<Term> {
+    fn into_church(self) -> Term {
+        match self {
             None => none(),
             Some(value) => abs!(2, app(Var(1), value))
         }

--- a/src/church/pair.rs
+++ b/src/church/pair.rs
@@ -3,6 +3,7 @@
 use term::{Term, abs, app};
 use term::Term::*;
 use church::boolean::{tru, fls};
+use church::conversions::IntoChurch;
 
 /// Produces a Church-encoded pair; applying it to two other terms puts them inside it.
 ///
@@ -14,8 +15,8 @@ use church::boolean::{tru, fls};
 /// use lambda_calculus::*;
 ///
 /// assert_eq!(
-///     beta(app!(pair(), 1.into(), 2.into()), NOR, 0),
-///     (1.into(), 2.into()).into()
+///     beta(app!(pair(), 1.into_church(), 2.into_church()), NOR, 0),
+///     (1, 2).into_church()
 /// );
 /// ```
 pub fn pair() -> Term {
@@ -32,8 +33,8 @@ pub fn pair() -> Term {
 /// use lambda_calculus::*;
 ///
 /// assert_eq!(
-///     beta(app(fst(), (1.into(), 2.into()).into()), NOR, 0),
-///     1.into()
+///     beta(app(fst(), (1, 2).into_church()), NOR, 0),
+///     1.into_church()
 /// );
 /// ```
 pub fn fst() -> Term { abs(app(Var(1), tru())) }
@@ -48,8 +49,8 @@ pub fn fst() -> Term { abs(app(Var(1), tru())) }
 /// use lambda_calculus::*;
 ///
 /// assert_eq!(
-///     beta(app(snd(), (1.into(), 2.into()).into()), NOR, 0),
-///     2.into()
+///     beta(app(snd(), (1, 2).into_church()), NOR, 0),
+///     2.into_church()
 /// );
 /// ```
 pub fn snd() -> Term { abs(app(Var(1), fls())) }
@@ -66,8 +67,8 @@ pub fn snd() -> Term { abs(app(Var(1), fls())) }
 /// use lambda_calculus::*;
 ///
 /// assert_eq!(
-///     beta(app!(uncurry(), plus(), (1.into(), 2.into()).into()), NOR, 0),
-///     3.into()
+///     beta(app!(uncurry(), plus(), (1, 2).into_church()), NOR, 0),
+///     3.into_church()
 /// );
 /// ```
 pub fn uncurry() -> Term {
@@ -89,8 +90,8 @@ pub fn uncurry() -> Term {
 /// use lambda_calculus::*;
 ///
 /// assert_eq!(
-///     beta(app!(curry(), fst(), 1.into(), 2.into()), NOR, 0),
-///     1.into()
+///     beta(app!(curry(), fst(), 1.into_church(), 2.into_church()), NOR, 0),
+///     1.into_church()
 /// );
 /// ```
 pub fn curry() -> Term {
@@ -110,7 +111,7 @@ pub fn curry() -> Term {
 /// use lambda_calculus::*;
 ///
 /// assert_eq!(
-///     beta(app!(swap(), (1.into(), 2.into()).into()), NOR, 0), (2.into(), 1.into()).into());
+///     beta(app!(swap(), (1, 2).into_church()), NOR, 0), (2, 1).into_church());
 /// ```
 pub fn swap() -> Term {
     abs!(2, app!(
@@ -120,8 +121,14 @@ pub fn swap() -> Term {
     ))
 }
 
-impl From<(Term, Term)> for Term {
-    fn from((t1, t2): (Term, Term)) -> Self {
-        abs(app!(Var(1), t1, t2))
+impl IntoChurch for (Term, Term) {
+    fn into_church(self) -> Term {
+        abs(app!(Var(1), self.0, self.1))
+    }
+}
+
+impl<T,U> IntoChurch for (T, U) where T:IntoChurch, U:IntoChurch {
+    fn into_church(self) -> Term {
+        abs(app!(Var(1), self.0.into_church(), self.1.into_church()))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,8 @@ pub mod term;
 pub mod parser;
 pub mod reduction;
 pub mod combinators;
-#[cfg(feature = "church")]
 pub mod church;
-#[cfg(feature = "scott")]
 pub mod scott;
-#[cfg(feature = "parigot")]
 pub mod parigot;
 
 pub use self::term::{Term, abs, app};
@@ -21,3 +18,7 @@ pub use self::term::Notation::*;
 pub use self::reduction::{beta, beta_verbose};
 pub use self::reduction::Order::*;
 pub use self::parser::parse;
+
+pub use self::church::conversions::IntoChurch;
+pub use self::scott::conversions::IntoScott;
+pub use self::parigot::conversions::IntoParigot;

--- a/src/parigot/conversions.rs
+++ b/src/parigot/conversions.rs
@@ -1,0 +1,18 @@
+//! Conversion to a Parigot-encoded `Term`
+
+use term::Term;
+
+/// Conversion to a Parigot-encoded lambda term
+pub trait IntoParigot {
+    /// Consume an object and return a Parigot-encoded `Term`
+    fn into_parigot(self) -> Term;
+}
+
+
+/// This impl can optionally be built using `features = parigot`.
+#[cfg(feature = "parigot")]
+impl<T> From<T> for Term where T:IntoParigot {
+    fn from(t: T) -> Self {
+        t.into_parigot()
+    }
+}

--- a/src/parigot/mod.rs
+++ b/src/parigot/mod.rs
@@ -1,3 +1,4 @@
 //! [Parigot-encoded](https://ir.uiowa.edu/cgi/viewcontent.cgi?article=5357&context=etd) data and operators
 
+pub mod conversions;
 pub mod numerals;

--- a/src/parigot/numerals.rs
+++ b/src/parigot/numerals.rs
@@ -2,6 +2,7 @@
 
 use term::{Term, abs};
 use term::Term::*;
+use parigot::conversions::IntoParigot;
 
 /// Produces a Parigot-encoded number zero.
 ///
@@ -12,7 +13,7 @@ use term::Term::*;
 /// use lambda_calculus::parigot::numerals::zero;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(zero(), 0.into());
+/// assert_eq!(zero(), 0.into_parigot());
 /// ```
 pub fn zero() -> Term { abs!(2, Var(1)) }
 
@@ -25,8 +26,8 @@ pub fn zero() -> Term { abs!(2, Var(1)) }
 /// use lambda_calculus::parigot::numerals::succ;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(succ(), 0.into()), NOR, 0), 1.into());
-/// assert_eq!(beta(app(succ(), 1.into()), NOR, 0), 2.into());
+/// assert_eq!(beta(app(succ(), 0.into_parigot()), NOR, 0), 1.into_parigot());
+/// assert_eq!(beta(app(succ(), 1.into_parigot()), NOR, 0), 2.into_parigot());
 /// ```
 pub fn succ() -> Term {
     abs!(3, app!(Var(2), Var(3), app!(Var(3), Var(2), Var(1))))
@@ -41,8 +42,8 @@ pub fn succ() -> Term {
 /// use lambda_calculus::parigot::numerals::pred;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(pred(), 1.into()), NOR, 0), 0.into());
-/// assert_eq!(beta(app(pred(), 3.into()), NOR, 0), 2.into());
+/// assert_eq!(beta(app(pred(), 1.into_parigot()), NOR, 0), 0.into_parigot());
+/// assert_eq!(beta(app(pred(), 3.into_parigot()), NOR, 0), 2.into_parigot());
 /// ```
 pub fn pred() -> Term {
     abs(app!(Var(1), abs!(2, Var(2)), zero()))
@@ -57,18 +58,18 @@ pub fn pred() -> Term {
 /// use lambda_calculus::parigot::numerals::plus;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app!(plus(), 1.into(), 2.into()), NOR, 0), 3.into());
-/// assert_eq!(beta(app!(plus(), 2.into(), 3.into()), NOR, 0), 5.into());
+/// assert_eq!(beta(app!(plus(), 1.into_parigot(), 2.into_parigot()), NOR, 0), 3.into_parigot());
+/// assert_eq!(beta(app!(plus(), 2.into_parigot(), 3.into_parigot()), NOR, 0), 5.into_parigot());
 /// ```
 pub fn plus() -> Term {
     abs!(2, app!(Var(2), abs(succ()), Var(1)))
 }
 
-impl From<usize> for Term {
-    fn from(n: usize) -> Self {
+impl IntoParigot for usize {
+    fn into_parigot(self) -> Term {
         let mut ret = zero();
 
-        for _ in 0..n {
+        for _ in 0..self {
             ret = abs!(2, app!(Var(2), ret.clone(), ret.unabs().and_then(|r| r.unabs()).unwrap()));
         }
 

--- a/src/scott/conversions.rs
+++ b/src/scott/conversions.rs
@@ -1,0 +1,17 @@
+//! Conversion to a Scott-encoded `Term`
+
+use term::Term;
+
+/// Conversion to a Scott-encoded lambda term
+pub trait IntoScott {
+    /// Consume an object and return a Scott-encoded `Term`
+    fn into_scott(self) -> Term;
+}
+
+/// This impl can optionally be built using `features = scott`.
+#[cfg(feature = "scott")]
+impl<T> From<T> for Term where T:IntoScott {
+    fn from(t: T) -> Self {
+        t.into_scott()
+    }
+}

--- a/src/scott/mod.rs
+++ b/src/scott/mod.rs
@@ -1,3 +1,4 @@
 //! [Scott-encoded](https://en.wikipedia.org/wiki/Mogensen%E2%80%93Scott_encoding) data and operators
 
+pub mod conversions;
 pub mod numerals;

--- a/src/scott/numerals.rs
+++ b/src/scott/numerals.rs
@@ -2,6 +2,7 @@
 
 use term::{Term, abs, app};
 use term::Term::*;
+use scott::conversions::IntoScott;
 
 /// Produces a Scott-encoded number zero.
 ///
@@ -12,7 +13,7 @@ use term::Term::*;
 /// use lambda_calculus::scott::numerals::zero;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(zero(), 0.into());
+/// assert_eq!(zero(), 0.into_scott());
 /// ```
 pub fn zero() -> Term { abs!(2, Var(2)) }
 
@@ -25,8 +26,8 @@ pub fn zero() -> Term { abs!(2, Var(2)) }
 /// use lambda_calculus::scott::numerals::succ;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(succ(), 0.into()), NOR, 0), 1.into());
-/// assert_eq!(beta(app(succ(), 1.into()), NOR, 0), 2.into());
+/// assert_eq!(beta(app(succ(), 0.into_scott()), NOR, 0), 1.into_scott());
+/// assert_eq!(beta(app(succ(), 1.into_scott()), NOR, 0), 2.into_scott());
 /// ```
 pub fn succ() -> Term {
     abs!(3, app(Var(1), Var(3)))
@@ -41,18 +42,18 @@ pub fn succ() -> Term {
 /// use lambda_calculus::scott::numerals::pred;
 /// use lambda_calculus::*;
 ///
-/// assert_eq!(beta(app(pred(), 1.into()), NOR, 0), 0.into());
-/// assert_eq!(beta(app(pred(), 3.into()), NOR, 0), 2.into());
+/// assert_eq!(beta(app(pred(), 1.into_scott()), NOR, 0), 0.into_scott());
+/// assert_eq!(beta(app(pred(), 3.into_scott()), NOR, 0), 2.into_scott());
 /// ```
 pub fn pred() -> Term {
     abs(app!(Var(1), zero(), abs(Var(1))))
 }
 
-impl From<usize> for Term {
-    fn from(n: usize) -> Self {
+impl IntoScott for usize {
+    fn into_scott(self) -> Term {
         let mut ret = abs!(2, Var(2));
 
-        for _ in 0..n {
+        for _ in 0..self {
             ret = abs!(2, app(Var(1), ret));
         }
 

--- a/tests/church_list.rs
+++ b/tests/church_list.rs
@@ -9,20 +9,20 @@ use lambda::church::boolean::fls;
 
 #[test]
 fn church_last() {
-    let list1 = || { Term::from(vec![1.into()]) };
-    let list2 = || { Term::from(vec![0.into(), 1.into(), 2.into(), 3.into(), 4.into()]) };
+    let list1 = || { vec![1].into_church() };
+    let list2 = || { vec![0, 1, 2, 3, 4].into_church() };
 
     assert_eq!(beta(app(last(), nil()), HAP, 0), nil());
-    assert_eq!(beta(app(last(), list1()), HAP, 0), 1.into());
-    assert_eq!(beta(app(last(), list2()), HAP, 0), 4.into());
+    assert_eq!(beta(app(last(), list1()), HAP, 0), 1.into_church());
+    assert_eq!(beta(app(last(), list2()), HAP, 0), 4.into_church());
 }
 
 #[test]
 fn church_init() {
-    let list1 = || { Term::from(vec![0.into(), 1.into(), 2.into(), 3.into(), 4.into()]) };
-    let list2 = || { Term::from(vec![0.into(), 1.into(), 2.into(), 3.into()]) };
-    let list3 = || { Term::from(vec![2.into(), 3.into()]) };
-    let list4 = || { Term::from(vec![2.into()]) };
+    let list1 = || { vec![0, 1, 2, 3, 4].into_church() };
+    let list2 = || { vec![0, 1, 2, 3].into_church() };
+    let list3 = || { vec![2, 3].into_church() };
+    let list4 = || { vec![2].into_church() };
 
     assert_eq!(beta(app(init(), list1()), HAP, 0), list2());
     assert_eq!(beta(app(init(), list3()), HAP, 0), list4());
@@ -32,20 +32,12 @@ fn church_init() {
 
 #[test]
 fn church_zip() {
-    let l1 = || { Term::from(vec![0.into()]) };
-    let l2 = || { Term::from(vec![0.into(), 1.into(), 2.into()]) };
-    let l3 = || { Term::from(vec![2.into(), 1.into()]) };
-
-    let p1 = || { Term::from(vec![(0.into(), 0.into()).into()]) }; // zip(l1, l1)
-    let p2 = || { Term::from(vec![
-        (0.into(), 0.into()).into(),
-        (1.into(), 1.into()).into(),
-        (2.into(), 2.into()).into(),
-    ])}; //zip(l2, l2)
-    let p3 = || { Term::from(vec![
-        (0.into(), 2.into()).into(),
-        (1.into(), 1.into()).into(),
-    ])}; // zip(l2, l3)
+    let l1 = || { vec![0].into_church() };
+    let l2 = || { vec![0, 1, 2].into_church() };
+    let l3 = || { vec![2, 1].into_church() };
+    let p1 = || { vec![(0, 0)].into_church() };
+    let p2 = || { vec![(0, 0), (1, 1), (2, 2)].into_church() };
+    let p3 = || { vec![(0, 2), (1, 1)].into_church() };
 
     assert_eq!(beta(app!(zip(), nil(), nil()), HAP, 0), nil());
     assert_eq!(beta(app!(zip(), nil(), l1()), HAP, 0), nil());
@@ -59,11 +51,11 @@ fn church_zip() {
 
 #[test]
 fn church_zip_with() {
-    let l1 = || { Term::from(vec![1.into()]) };
-    let l2 = || { Term::from(vec![2.into()]) };
-    let l3 = || { Term::from(vec![1.into(), 2.into(), 3.into()]) };
-    let l4 = || { Term::from(vec![2.into(), 4.into(), 6.into()]) };
-    let l5 = || { Term::from(vec![3.into()]) };
+    let l1 = || { vec![1].into_church() };
+    let l2 = || { vec![2].into_church() };
+    let l3 = || { vec![1, 2, 3].into_church() };
+    let l4 = || { vec![2, 4, 6].into_church() };
+    let l5 = || { vec![3].into_church() };
 
     assert_eq!(beta(app!(zip_with(), plus(), nil(), nil()), HAP, 0), nil());
     assert_eq!(beta(app!(zip_with(), plus(), l1(), nil()), HAP, 0), nil());
@@ -79,29 +71,29 @@ fn church_zip_with() {
 
 #[test]
 fn church_take() {
-    let l1 = || { Term::from(vec![0.into()]) };
-    let l2 = || { Term::from(vec![0.into(), 1.into()]) };
-    let l3 = || { Term::from(vec![0.into(), 1.into(), 2.into()]) };
-    let l4 = || { Term::from(vec![0.into(), 1.into(), 2.into(), 3.into()]) };
+    let l1 = || { vec![0].into_church() };
+    let l2 = || { vec![0, 1].into_church() };
+    let l3 = || { vec![0, 1, 2].into_church() };
+    let l4 = || { vec![0, 1, 2, 3].into_church() };
 
-    assert_eq!(beta(app!(take(), 5.into(), l4()), HAP, 0), l4());
-    assert_eq!(beta(app!(take(), 4.into(), l4()), HAP, 0), l4());
-    assert_eq!(beta(app!(take(), 3.into(), l4()), HAP, 0), l3());
-    assert_eq!(beta(app!(take(), 2.into(), l4()), HAP, 0), l2());
-    assert_eq!(beta(app!(take(), 1.into(), l4()), HAP, 0), l1());
-    assert_eq!(beta(app!(take(), 0.into(), l4()), HAP, 0), nil());
-    assert_eq!(beta(app!(take(), 1.into(), l1()), HAP, 0), l1());
-    assert_eq!(beta(app!(take(), 0.into(), l1()), HAP, 0), nil());
-    assert_eq!(beta(app!(take(), 1.into(), nil()), HAP, 0), nil());
+    assert_eq!(beta(app!(take(), 5.into_church(), l4()), HAP, 0), l4());
+    assert_eq!(beta(app!(take(), 4.into_church(), l4()), HAP, 0), l4());
+    assert_eq!(beta(app!(take(), 3.into_church(), l4()), HAP, 0), l3());
+    assert_eq!(beta(app!(take(), 2.into_church(), l4()), HAP, 0), l2());
+    assert_eq!(beta(app!(take(), 1.into_church(), l4()), HAP, 0), l1());
+    assert_eq!(beta(app!(take(), 0.into_church(), l4()), HAP, 0), nil());
+    assert_eq!(beta(app!(take(), 1.into_church(), l1()), HAP, 0), l1());
+    assert_eq!(beta(app!(take(), 0.into_church(), l1()), HAP, 0), nil());
+    assert_eq!(beta(app!(take(), 1.into_church(), nil()), HAP, 0), nil());
 }
 
 #[test]
 fn church_take_while() {
-    let l1 = || { Term::from(vec![0.into(), 0.into(), 2.into(), 3.into()]) };
-    let l2 = || { Term::from(vec![0.into(), 0.into()]) };
-    let l3 = || { Term::from(vec![1.into(), 4.into(), 2.into(), 3.into()]) };
-    let l4 = || { Term::from(vec![0.into(), 4.into(), 0.into(), 0.into()]) };
-    let l5 = || { Term::from(vec![0.into()]) };
+    let l1 = || { vec![0, 0, 2, 3].into_church() };
+    let l2 = || { vec![0, 0].into_church() };
+    let l3 = || { vec![1, 4, 2, 3].into_church() };
+    let l4 = || { vec![0, 4, 0, 0].into_church() };
+    let l5 = || { vec![0].into_church() };
 
     assert_eq!(beta(app!(take_while(), is_zero(), nil()), HAP, 0), nil());
     assert_eq!(beta(app!(take_while(), is_zero(), l1()), HAP, 0), l2());

--- a/tests/church_numerals.rs
+++ b/tests/church_numerals.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "church")]
-
 #[macro_use]
 extern crate lambda_calculus as lambda;
 
@@ -9,133 +7,133 @@ use lambda::combinators::C;
 
 #[test]
 fn church_succ() {
-    assert_eq!(beta(app!(succ(), 0.into()), HAP, 0), 1.into());
-    assert_eq!(beta(app!(succ(), 1.into()), HAP, 0), 2.into());
-    assert_eq!(beta(app!(succ(), 2.into()), HAP, 0), 3.into());
+    assert_eq!(beta(app!(succ(), 0.into_church()), HAP, 0), 1.into_church());
+    assert_eq!(beta(app!(succ(), 1.into_church()), HAP, 0), 2.into_church());
+    assert_eq!(beta(app!(succ(), 2.into_church()), HAP, 0), 3.into_church());
 }
 
 #[test]
 fn church_pred() {
-    assert_eq!(beta(app!(pred(), 0.into()), HAP, 0), 0.into());
-    assert_eq!(beta(app!(pred(), 1.into()), HAP, 0), 0.into());
-    assert_eq!(beta(app!(pred(), 5.into()), HAP, 0), 4.into());
+    assert_eq!(beta(app!(pred(), 0.into_church()), HAP, 0), 0.into_church());
+    assert_eq!(beta(app!(pred(), 1.into_church()), HAP, 0), 0.into_church());
+    assert_eq!(beta(app!(pred(), 5.into_church()), HAP, 0), 4.into_church());
 }
 
 #[test]
 fn church_plus_sub() {
-    assert_eq!(beta(app!(    plus(), 1.into()), HAP, 0), succ());
-    assert_eq!(beta(app!(C(), sub(), 1.into()), HAP, 0), pred());
+    assert_eq!(beta(app!(    plus(), 1.into_church()), HAP, 0), succ());
+    assert_eq!(beta(app!(C(), sub(), 1.into_church()), HAP, 0), pred());
 }
 
 #[test]
 fn church_mult() {
-    assert_eq!(beta(app!(mult(), 3.into(), 4.into()), HAP, 0), 12.into());
-    assert_eq!(beta(app!(mult(), 1.into(), 3.into()), HAP, 0),  3.into());
-    assert_eq!(beta(app!(mult(), 3.into(), 1.into()), HAP, 0),  3.into());
-    assert_eq!(beta(app!(mult(), 5.into(), 0.into()), HAP, 0),  0.into());
-    assert_eq!(beta(app!(mult(), 0.into(), 5.into()), HAP, 0),  0.into());
+    assert_eq!(beta(app!(mult(), 3.into_church(), 4.into_church()), HAP, 0), 12.into_church());
+    assert_eq!(beta(app!(mult(), 1.into_church(), 3.into_church()), HAP, 0),  3.into_church());
+    assert_eq!(beta(app!(mult(), 3.into_church(), 1.into_church()), HAP, 0),  3.into_church());
+    assert_eq!(beta(app!(mult(), 5.into_church(), 0.into_church()), HAP, 0),  0.into_church());
+    assert_eq!(beta(app!(mult(), 0.into_church(), 5.into_church()), HAP, 0),  0.into_church());
 }
 
 #[test]
 fn church_pow() {
-    assert_eq!(beta(app!(pow(), 2.into(), 4.into()), HAP, 0), 16.into());
-    assert_eq!(beta(app!(pow(), 1.into(), 3.into()), HAP, 0),  1.into());
-    assert_eq!(beta(app!(pow(), 3.into(), 1.into()), HAP, 0),  3.into());
-    assert_eq!(beta(app!(pow(), 5.into(), 0.into()), HAP, 0),  1.into());
-    assert_eq!(beta(app!(pow(), 0.into(), 5.into()), HAP, 0),  0.into());
+    assert_eq!(beta(app!(pow(), 2.into_church(), 4.into_church()), HAP, 0), 16.into_church());
+    assert_eq!(beta(app!(pow(), 1.into_church(), 3.into_church()), HAP, 0),  1.into_church());
+    assert_eq!(beta(app!(pow(), 3.into_church(), 1.into_church()), HAP, 0),  3.into_church());
+    assert_eq!(beta(app!(pow(), 5.into_church(), 0.into_church()), HAP, 0),  1.into_church());
+    assert_eq!(beta(app!(pow(), 0.into_church(), 5.into_church()), HAP, 0),  0.into_church());
 }
 
 #[test]
 fn church_div() {
-    assert_eq!(beta(app!(div(), 2.into(), 2.into()), HAP, 0), (1.into(), 0.into()).into());
-    assert_eq!(beta(app!(div(), 3.into(), 2.into()), HAP, 0), (1.into(), 1.into()).into());
-    assert_eq!(beta(app!(div(), 5.into(), 2.into()), HAP, 0), (2.into(), 1.into()).into());
-    assert_eq!(beta(app!(div(), 2.into(), 1.into()), HAP, 0), (2.into(), 0.into()).into());
-    assert_eq!(beta(app!(div(), 0.into(), 3.into()), HAP, 0), (0.into(), 0.into()).into());
+    assert_eq!(beta(app!(div(), 2.into_church(), 2.into_church()), HAP, 0), (1.into_church(), 0.into_church()).into_church());
+    assert_eq!(beta(app!(div(), 3.into_church(), 2.into_church()), HAP, 0), (1.into_church(), 1.into_church()).into_church());
+    assert_eq!(beta(app!(div(), 5.into_church(), 2.into_church()), HAP, 0), (2.into_church(), 1.into_church()).into_church());
+    assert_eq!(beta(app!(div(), 2.into_church(), 1.into_church()), HAP, 0), (2.into_church(), 0.into_church()).into_church());
+    assert_eq!(beta(app!(div(), 0.into_church(), 3.into_church()), HAP, 0), (0.into_church(), 0.into_church()).into_church());
 }
 
 #[test]
 fn church_quot() {
-    assert_eq!(beta(app!(quot(), 2.into(), 2.into()), HAP, 0), 1.into());
-    assert_eq!(beta(app!(quot(), 3.into(), 2.into()), HAP, 0), 1.into());
-    assert_eq!(beta(app!(quot(), 5.into(), 2.into()), HAP, 0), 2.into());
-    assert_eq!(beta(app!(quot(), 2.into(), 1.into()), HAP, 0), 2.into());
-    assert_eq!(beta(app!(quot(), 0.into(), 3.into()), HAP, 0), 0.into());
+    assert_eq!(beta(app!(quot(), 2.into_church(), 2.into_church()), HAP, 0), 1.into_church());
+    assert_eq!(beta(app!(quot(), 3.into_church(), 2.into_church()), HAP, 0), 1.into_church());
+    assert_eq!(beta(app!(quot(), 5.into_church(), 2.into_church()), HAP, 0), 2.into_church());
+    assert_eq!(beta(app!(quot(), 2.into_church(), 1.into_church()), HAP, 0), 2.into_church());
+    assert_eq!(beta(app!(quot(), 0.into_church(), 3.into_church()), HAP, 0), 0.into_church());
 }
 
 #[test]
 fn church_rem() {
-    assert_eq!(beta(app!(rem(), 2.into(), 2.into()), HAP, 0), 0.into());
-    assert_eq!(beta(app!(rem(), 3.into(), 2.into()), HAP, 0), 1.into());
-    assert_eq!(beta(app!(rem(), 2.into(), 5.into()), HAP, 0), 2.into());
-    assert_eq!(beta(app!(rem(), 2.into(), 1.into()), HAP, 0), 0.into());
-    assert_eq!(beta(app!(rem(), 0.into(), 3.into()), HAP, 0), 0.into());
+    assert_eq!(beta(app!(rem(), 2.into_church(), 2.into_church()), HAP, 0), 0.into_church());
+    assert_eq!(beta(app!(rem(), 3.into_church(), 2.into_church()), HAP, 0), 1.into_church());
+    assert_eq!(beta(app!(rem(), 2.into_church(), 5.into_church()), HAP, 0), 2.into_church());
+    assert_eq!(beta(app!(rem(), 2.into_church(), 1.into_church()), HAP, 0), 0.into_church());
+    assert_eq!(beta(app!(rem(), 0.into_church(), 3.into_church()), HAP, 0), 0.into_church());
 }
 
 #[test]
 fn church_fac() {
-    assert_eq!(beta(app!(fac(), 0.into()), HAP, 0), 1.into());
-    assert_eq!(beta(app!(fac(), 1.into()), HAP, 0), 1.into());
-    assert_eq!(beta(app!(fac(), 2.into()), HAP, 0), 2.into());
-    assert_eq!(beta(app!(fac(), 3.into()), HAP, 0), 6.into());
+    assert_eq!(beta(app!(fac(), 0.into_church()), HAP, 0), 1.into_church());
+    assert_eq!(beta(app!(fac(), 1.into_church()), HAP, 0), 1.into_church());
+    assert_eq!(beta(app!(fac(), 2.into_church()), HAP, 0), 2.into_church());
+    assert_eq!(beta(app!(fac(), 3.into_church()), HAP, 0), 6.into_church());
 }
 
 #[test]
 fn church_min() {
-    assert_eq!(beta(app!(min(), 0.into(), 0.into()), HAP, 0), 0.into());
-    assert_eq!(beta(app!(min(), 4.into(), 4.into()), HAP, 0), 4.into());
-    assert_eq!(beta(app!(min(), 2.into(), 3.into()), HAP, 0), 2.into());
-    assert_eq!(beta(app!(min(), 5.into(), 3.into()), HAP, 0), 3.into());
-    assert_eq!(beta(app!(min(), 0.into(), 1.into()), HAP, 0), 0.into());
+    assert_eq!(beta(app!(min(), 0.into_church(), 0.into_church()), HAP, 0), 0.into_church());
+    assert_eq!(beta(app!(min(), 4.into_church(), 4.into_church()), HAP, 0), 4.into_church());
+    assert_eq!(beta(app!(min(), 2.into_church(), 3.into_church()), HAP, 0), 2.into_church());
+    assert_eq!(beta(app!(min(), 5.into_church(), 3.into_church()), HAP, 0), 3.into_church());
+    assert_eq!(beta(app!(min(), 0.into_church(), 1.into_church()), HAP, 0), 0.into_church());
 }
 
 #[test]
 fn church_max() {
-    assert_eq!(beta(app!(max(), 0.into(), 0.into()), HAP, 0), 0.into());
-    assert_eq!(beta(app!(max(), 4.into(), 4.into()), HAP, 0), 4.into());
-    assert_eq!(beta(app!(max(), 2.into(), 3.into()), HAP, 0), 3.into());
-    assert_eq!(beta(app!(max(), 5.into(), 3.into()), HAP, 0), 5.into());
-    assert_eq!(beta(app!(max(), 0.into(), 1.into()), HAP, 0), 1.into());
+    assert_eq!(beta(app!(max(), 0.into_church(), 0.into_church()), HAP, 0), 0.into_church());
+    assert_eq!(beta(app!(max(), 4.into_church(), 4.into_church()), HAP, 0), 4.into_church());
+    assert_eq!(beta(app!(max(), 2.into_church(), 3.into_church()), HAP, 0), 3.into_church());
+    assert_eq!(beta(app!(max(), 5.into_church(), 3.into_church()), HAP, 0), 5.into_church());
+    assert_eq!(beta(app!(max(), 0.into_church(), 1.into_church()), HAP, 0), 1.into_church());
 }
 
 #[test]
 fn church_lshift() {
-     assert_eq!(beta(app!(lshift(), 0.into(), 2.into()), HAP, 0), 0.into());
-     assert_eq!(beta(app!(lshift(), 1.into(), 0.into()), HAP, 0), 1.into());
-     assert_eq!(beta(app!(lshift(), 2.into(), 0.into()), HAP, 0), 2.into());
-     assert_eq!(beta(app!(lshift(), 2.into(), 2.into()), HAP, 0), 8.into());
-     assert_eq!(beta(app!(lshift(), 3.into(), 2.into()), HAP, 0), 12.into());
-     assert_eq!(beta(app!(lshift(), 2.into(), 3.into()), HAP, 0), 16.into());
-     assert_eq!(beta(app!(lshift(), 5.into(), 1.into()), HAP, 0), 10.into());
+     assert_eq!(beta(app!(lshift(), 0.into_church(), 2.into_church()), HAP, 0), 0.into_church());
+     assert_eq!(beta(app!(lshift(), 1.into_church(), 0.into_church()), HAP, 0), 1.into_church());
+     assert_eq!(beta(app!(lshift(), 2.into_church(), 0.into_church()), HAP, 0), 2.into_church());
+     assert_eq!(beta(app!(lshift(), 2.into_church(), 2.into_church()), HAP, 0), 8.into_church());
+     assert_eq!(beta(app!(lshift(), 3.into_church(), 2.into_church()), HAP, 0), 12.into_church());
+     assert_eq!(beta(app!(lshift(), 2.into_church(), 3.into_church()), HAP, 0), 16.into_church());
+     assert_eq!(beta(app!(lshift(), 5.into_church(), 1.into_church()), HAP, 0), 10.into_church());
 }
 
 #[test]
 fn church_rshift() {
-     assert_eq!(beta(app!(rshift(), 1.into(), 0.into()), HAP, 0), 1.into());
-     assert_eq!(beta(app!(rshift(), 2.into(), 0.into()), HAP, 0), 2.into());
-     assert_eq!(beta(app!(rshift(), 0.into(), 2.into()), HAP, 0), 0.into());
-     assert_eq!(beta(app!(rshift(), 2.into(), 1.into()), HAP, 0), 1.into());
-     assert_eq!(beta(app!(rshift(), 2.into(), 2.into()), HAP, 0), 0.into());
-     assert_eq!(beta(app!(rshift(), 5.into(), 1.into()), HAP, 0), 2.into());
-     assert_eq!(beta(app!(rshift(), 9.into(), 1.into()), HAP, 0), 4.into());
-     assert_eq!(beta(app!(rshift(), 9.into(), 2.into()), HAP, 0), 2.into());
-     assert_eq!(beta(app!(rshift(), 7.into(), 1.into()), HAP, 0), 3.into());
+     assert_eq!(beta(app!(rshift(), 1.into_church(), 0.into_church()), HAP, 0), 1.into_church());
+     assert_eq!(beta(app!(rshift(), 2.into_church(), 0.into_church()), HAP, 0), 2.into_church());
+     assert_eq!(beta(app!(rshift(), 0.into_church(), 2.into_church()), HAP, 0), 0.into_church());
+     assert_eq!(beta(app!(rshift(), 2.into_church(), 1.into_church()), HAP, 0), 1.into_church());
+     assert_eq!(beta(app!(rshift(), 2.into_church(), 2.into_church()), HAP, 0), 0.into_church());
+     assert_eq!(beta(app!(rshift(), 5.into_church(), 1.into_church()), HAP, 0), 2.into_church());
+     assert_eq!(beta(app!(rshift(), 9.into_church(), 1.into_church()), HAP, 0), 4.into_church());
+     assert_eq!(beta(app!(rshift(), 9.into_church(), 2.into_church()), HAP, 0), 2.into_church());
+     assert_eq!(beta(app!(rshift(), 7.into_church(), 1.into_church()), HAP, 0), 3.into_church());
 }
 
 #[test]
 fn church_is_even() {
-     assert_eq!(beta(app!(is_even(), 0.into()), HAP, 0), true.into());
-     assert_eq!(beta(app!(is_even(), 1.into()), HAP, 0), false.into());
-     assert_eq!(beta(app!(is_even(), 2.into()), HAP, 0), true.into());
-     assert_eq!(beta(app!(is_even(), 8.into()), HAP, 0), true.into());
-     assert_eq!(beta(app!(is_even(), 9.into()), HAP, 0), false.into());
+     assert_eq!(beta(app!(is_even(), 0.into_church()), HAP, 0), true.into_church());
+     assert_eq!(beta(app!(is_even(), 1.into_church()), HAP, 0), false.into_church());
+     assert_eq!(beta(app!(is_even(), 2.into_church()), HAP, 0), true.into_church());
+     assert_eq!(beta(app!(is_even(), 8.into_church()), HAP, 0), true.into_church());
+     assert_eq!(beta(app!(is_even(), 9.into_church()), HAP, 0), false.into_church());
 }
 
 #[test]
 fn church_is_odd() {
-     assert_eq!(beta(app!(is_odd(), 0.into()), HAP, 0), false.into());
-     assert_eq!(beta(app!(is_odd(), 1.into()), HAP, 0), true.into());
-     assert_eq!(beta(app!(is_odd(), 2.into()), HAP, 0), false.into());
-     assert_eq!(beta(app!(is_odd(), 8.into()), HAP, 0), false.into());
-     assert_eq!(beta(app!(is_odd(), 9.into()), HAP, 0), true.into());
+     assert_eq!(beta(app!(is_odd(), 0.into_church()), HAP, 0), false.into_church());
+     assert_eq!(beta(app!(is_odd(), 1.into_church()), HAP, 0), true.into_church());
+     assert_eq!(beta(app!(is_odd(), 2.into_church()), HAP, 0), false.into_church());
+     assert_eq!(beta(app!(is_odd(), 8.into_church()), HAP, 0), false.into_church());
+     assert_eq!(beta(app!(is_odd(), 9.into_church()), HAP, 0), true.into_church());
 }

--- a/tests/church_option.rs
+++ b/tests/church_option.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "church")]
-
 extern crate lambda_calculus as lambda;
 
 use lambda::*;
@@ -8,28 +6,28 @@ use lambda::church::numerals::succ;
 
 #[test]
 fn church_none() {
-    assert_eq!(beta(None.into(), HAP, 0), none());
+    assert_eq!(beta(None.into_church(), HAP, 0), none());
 }
 
 #[test]
 fn church_some() {
-    assert_eq!(beta(app(some(), 3.into()), HAP, 0), Some(3.into()).into());
+    assert_eq!(beta(app(some(), 3.into_church()), HAP, 0), Some(3.into_church()).into_church());
 }
 
 #[test]
 fn church_is_some() {
-    assert_eq!(beta(app(is_some(), None.into()), HAP, 0), false.into());
-    assert_eq!(beta(app(is_some(), Some(3.into()).into()), HAP, 0), true.into());
+    assert_eq!(beta(app(is_some(), None.into_church()), HAP, 0), false.into_church());
+    assert_eq!(beta(app(is_some(), Some(3.into_church()).into_church()), HAP, 0), true.into_church());
 }
 
 #[test]
 fn church_is_none() {
-    assert_eq!(beta(app(is_none(), None.into()), HAP, 0), true.into());
-    assert_eq!(beta(app(is_none(), Some(3.into()).into()), HAP, 0), false.into());
+    assert_eq!(beta(app(is_none(), None.into_church()), HAP, 0), true.into_church());
+    assert_eq!(beta(app(is_none(), Some(3.into_church()).into_church()), HAP, 0), false.into_church());
 }
 
 #[test]
 fn church_map_or() {
-    assert_eq!(beta(app!(map_or(), 5.into(), succ(), None.into()), HAP, 0), 5.into());
-    assert_eq!(beta(app!(map_or(), 5.into(), succ(), Some(1.into()).into()), HAP, 0), 2.into());
+    assert_eq!(beta(app!(map_or(), 5.into_church(), succ(), None.into_church()), HAP, 0), 5.into_church());
+    assert_eq!(beta(app!(map_or(), 5.into_church(), succ(), Some(1.into_church()).into_church()), HAP, 0), 2.into_church());
 }

--- a/tests/church_option.rs
+++ b/tests/church_option.rs
@@ -34,6 +34,6 @@ fn church_map_or() {
 
 #[test]
 fn church_unwrap_or() {
-    assert_eq!(beta(app!(unwrap_or(), 5.into(), None.into()), HAP, 0), 5.into());
-    assert_eq!(beta(app!(unwrap_or(), 5.into(), Some(1.into()).into()), HAP, 0), 1.into());
+    assert_eq!(beta(app!(unwrap_or(), 5.into_church(), None.into_church()), HAP, 0), 5.into_church());
+    assert_eq!(beta(app!(unwrap_or(), 5.into_church(), Some(1.into_church()).into_church()), HAP, 0), 1.into_church());
 }


### PR DESCRIPTION
This is a pretty significant overhaul of the way conversions currently work. There are definitely tradeoffs and I'm not sure if the changes are worth it.

The docs for these traits aren't fully written and there are probably a lot more things that can be cleaned up. Also need to add tests for the `From` impl in each of the different compilation modes.

Advantages:
* Everything can be compiled at the same time, with the exception of the `From` impl for each encoding
* (Because I added implementations of these traits with type parameters) it's easier to convert complex structures (e.g. lists of pairs) to `Term`s 

Disadvantages:
* Increased verbosity
* In tests/doctests, `1.into()` now has to become `1.into_church()` or `1.into_scott()`
* Need to make the conversion traits visible in the top-level module (unless there is a better way of doing this)