### PR TITLE
add church_to_scott function

### DIFF
--- a/src/data/numerals/church.rs
+++ b/src/data/numerals/church.rs
@@ -3,6 +3,7 @@
 use term::{Term, abs, app};
 use term::Term::*;
 use data::boolean::{tru, fls};
+use data::numerals::scott;
 use combinators::Z;
 
 /// Produces a Church-encoded number zero.
@@ -650,4 +651,21 @@ pub fn is_even() -> Term {
 /// ```
 pub fn is_odd() -> Term {
     abs(app!(Var(1), abs(app!(Var(1), fls(), tru())), fls()))
+}
+
+/// Applied to a Church-encoded number it produces the equivalent Scott-encoded number.
+///
+/// TO_SCOTT := λn.n SUCC ZERO = λ 1 SUCC ZERO
+///
+/// # Example
+/// ```
+/// use lambda_calculus::data::numerals::church::to_scott;
+/// use lambda_calculus::*;
+///
+/// assert_eq!(beta(app(to_scott(), 0.into_church()), NOR, 0), 0.into_scott());
+/// assert_eq!(beta(app(to_scott(), 1.into_church()), NOR, 0), 1.into_scott());
+/// assert_eq!(beta(app(to_scott(), 2.into_church()), NOR, 0), 2.into_scott());
+/// ```
+pub fn to_scott() -> Term {
+    abs(app!(Var(1), scott::succ(), scott::zero()))
 }

--- a/src/data/numerals/scott.rs
+++ b/src/data/numerals/scott.rs
@@ -79,3 +79,20 @@ pub fn succ() -> Term {
 pub fn pred() -> Term {
     abs(app!(Var(1), zero(), abs(Var(1))))
 }
+
+/// Applied to a Church-encoded number it produces the equivalent Scott-encoded number.
+///
+/// CHURCH_TO_SCOTT := λn.n SUCC ZERO = λ 1 SUCC ZERO
+///
+/// # Example
+/// ```
+/// use lambda_calculus::data::numerals::scott::church_to_scott;
+/// use lambda_calculus::*;
+///
+/// assert_eq!(beta(app(church_to_scott(), 0.into_church()), NOR, 0), 0.into_scott());
+/// assert_eq!(beta(app(church_to_scott(), 1.into_church()), NOR, 0), 1.into_scott());
+/// assert_eq!(beta(app(church_to_scott(), 2.into_church()), NOR, 0), 2.into_scott());
+/// ```
+pub fn church_to_scott() -> Term {
+    abs(app!(Var(1), succ(), zero()))
+}

--- a/src/data/numerals/scott.rs
+++ b/src/data/numerals/scott.rs
@@ -79,20 +79,3 @@ pub fn succ() -> Term {
 pub fn pred() -> Term {
     abs(app!(Var(1), zero(), abs(Var(1))))
 }
-
-/// Applied to a Church-encoded number it produces the equivalent Scott-encoded number.
-///
-/// CHURCH_TO_SCOTT := λn.n SUCC ZERO = λ 1 SUCC ZERO
-///
-/// # Example
-/// ```
-/// use lambda_calculus::data::numerals::scott::church_to_scott;
-/// use lambda_calculus::*;
-///
-/// assert_eq!(beta(app(church_to_scott(), 0.into_church()), NOR, 0), 0.into_scott());
-/// assert_eq!(beta(app(church_to_scott(), 1.into_church()), NOR, 0), 1.into_scott());
-/// assert_eq!(beta(app(church_to_scott(), 2.into_church()), NOR, 0), 2.into_scott());
-/// ```
-pub fn church_to_scott() -> Term {
-    abs(app!(Var(1), succ(), zero()))
-}


### PR DESCRIPTION
I think this is useful, but I'm not sure how it should fit in with the existing API or where it should go. Putting it here as a placeholder.

It is also possible to convert from Scott-encoded to Church-encoded numerals, but I haven't been able to get this to work with both normal-order and applicative-order reduction (the normal-order version of my attempt at `scott_to_church` is below). The problem is of course the inner "loop" which just folds over the Scott numeral.

```rust
pub fn scott_to_church() -> Term {
    abs!(3, app!(
        app(
            Z(),
            abs!(4, app!(
                Var(1),
                Var(2),
                abs(app(Var(4), app!(Var(5), Var(4), Var(3), Var(1))))
            ))
        ),
        Var(2),
        Var(1),
        Var(3)
    ))
}

// test cases:
assert_eq!(beta(app(scott_to_church(), 0.into_scott()), NOR, 0), 0.into_church());
assert_eq!(beta(app(scott_to_church(), 1.into_scott()), NOR, 0), 1.into_church());
assert_eq!(beta(app(scott_to_church(), 2.into_scott()), NOR, 0), 2.into_church());

// stack overflows with this version:
assert_eq!(beta(app(scott_to_church(), 0.into_scott()), HAP, 0), 0.into_church());
assert_eq!(beta(app(scott_to_church(), 1.into_scott()), HAP, 0), 1.into_church());
assert_eq!(beta(app(scott_to_church(), 2.into_scott()), HAP, 0), 2.into_church());
```