### PR TITLE
add Turing's combinator in CBV form

### DIFF
--- a/src/combinators.rs
+++ b/src/combinators.rs
@@ -231,7 +231,7 @@ pub fn R() -> Term {
     abs!(2, app(Var(1), Var(2)))
 }
 
-/// Θ - Turing's fixed-point combinator (call-by-value form)
+/// Θ - Turing's fixed-point combinator
 ///
 /// Θ := (λxy.y (x x y)) (λxy.y (x x y)) = (λ λ 1 (2 2 1)) (λ λ 1 (2 2 1))
 ///

--- a/src/combinators.rs
+++ b/src/combinators.rs
@@ -233,26 +233,26 @@ pub fn R() -> Term {
 
 /// Θ - Turing's fixed-point combinator (call-by-value form)
 ///
-/// Θ := (λxy.y (λz.x x y)) (λxy.y (λz.x x y)) = (λ λ 1 (λ 3 3 2)) (λ λ 1 (λ 3 3 2))
+/// Θ := (λxy.y (x x y)) (λxy.y (x x y)) = (λ λ 1 (2 2 1)) (λ λ 1 (2 2 1))
 ///
-/// It is suitable for `NOR` (normal), `HNO` (hybrid normal), `CBN` (call-by-name), `CBV`
-/// (call-by-value), and `HSP` (head spine) reduction `Order`s.
+/// It is suitable for `NOR` (normal), `HNO` (hybrid normal), `CBN` (call-by-name), and `HSP` (head
+/// spine) reduction `Order`s.
 ///
 /// # Example
 /// ```
-/// use lambda_calculus::combinators::t;
+/// use lambda_calculus::combinators::T;
 /// use lambda_calculus::*;
 ///
 /// fn dummy() -> Term { abs(Var(2)) } // a dummy term that won't easily reduce
 ///
 /// assert_eq!(
-///     beta(app(t(), dummy()), CBV, 0),
-///     beta(app(dummy(), app(t(), dummy())), CBV, 0)
+///     beta(app(T(), dummy()), NOR, 0),
+///     beta(app(dummy(), app(T(), dummy())), NOR, 0)
 /// );
 /// ```
-pub fn t() -> Term {
+pub fn T() -> Term {
     app(
-        abs!(2, app(Var(1), abs(app!(Var(3), Var(3), Var(2))))),
-        abs!(2, app(Var(1), abs(app!(Var(3), Var(3), Var(2)))))
+        abs!(2, app(Var(1), app!(Var(2), Var(2), Var(1)))),
+        abs!(2, app(Var(1), app!(Var(2), Var(2), Var(1))))
     )
 }

--- a/src/combinators.rs
+++ b/src/combinators.rs
@@ -230,3 +230,29 @@ pub fn Z() -> Term {
 pub fn R() -> Term {
     abs!(2, app(Var(1), Var(2)))
 }
+
+/// Θ - Turing's fixed-point combinator (call-by-value form)
+///
+/// Θ := (λxy.y (λz.x x y)) (λxy.y (λz.x x y)) = (λ λ 1 (λ 3 3 2)) (λ λ 1 (λ 3 3 2))
+///
+/// It is suitable for `NOR` (normal), `HNO` (hybrid normal), `CBN` (call-by-name), `CBV`
+/// (call-by-value), and `HSP` (head spine) reduction `Order`s.
+///
+/// # Example
+/// ```
+/// use lambda_calculus::combinators::t;
+/// use lambda_calculus::*;
+///
+/// fn dummy() -> Term { abs(Var(2)) } // a dummy term that won't easily reduce
+///
+/// assert_eq!(
+///     beta(app(t(), dummy()), CBV, 0),
+///     beta(app(dummy(), app(t(), dummy())), CBV, 0)
+/// );
+/// ```
+pub fn t() -> Term {
+    app(
+        abs!(2, app(Var(1), abs(app!(Var(3), Var(3), Var(2))))),
+        abs!(2, app(Var(1), abs(app!(Var(3), Var(3), Var(2)))))
+    )
+}


### PR DESCRIPTION
I'm not sure if it's worth having the CBV-compatible form or the non-CBV-compatible form or both.

I added just the CBV-compatible form here because it's more general, but if you'd prefer something different I'm happy to make changes.