### PR TITLE
fully reduce pair and boolean functions

### DIFF
--- a/src/data/boolean.rs
+++ b/src/data/boolean.rs
@@ -82,7 +82,11 @@ pub fn not() -> Term {
 pub fn xor() -> Term {
     abs!(2, app!(
         Var(2),
-        app!(not(), Var(1)),
+        app!(
+            Var(1),
+            abs!(2, Var(1)),
+            abs!(2, Var(2))
+        ),
         Var(1)
     ))
 }
@@ -130,7 +134,11 @@ pub fn xnor() -> Term {
     abs!(2, app!(
         Var(2),
         Var(1),
-        app(not(), Var(1))
+        app!(
+            Var(1),
+            abs!(2, Var(1)),
+            abs!(2, Var(2))
+        )
     ))
 }
 
@@ -191,8 +199,14 @@ pub fn if_else() -> Term {
 /// ```
 pub fn imply() -> Term {
     abs!(2, app!(
-        or(),
-        app(not(), Var(2)),
+        Var(2),
+        abs!(2, Var(1)),
+        abs!(2, Var(2)),
+        app!(
+            Var(2),
+            abs!(2, Var(1)),
+            abs!(2, Var(2))
+        ),
         Var(1)
     ))
 }

--- a/src/data/pair.rs
+++ b/src/data/pair.rs
@@ -96,8 +96,8 @@ pub fn uncurry() -> Term {
 pub fn curry() -> Term {
     abs!(3, app(
         Var(3),
-        app!(pair(), Var(2), Var(1))
-    ))
+        abs(app!(Var(1), Var(3), Var(2))))
+    )
 }
 
 /// Applied to a lambda-encoded pair `(a, b)` it swaps its elements so that it becomes `(b, a)`.
@@ -115,10 +115,10 @@ pub fn curry() -> Term {
 /// );
 /// ```
 pub fn swap() -> Term {
-    abs(app!(
-        pair(),
-        app(snd(), Var(1)),
-        app(fst(), Var(1))
+    abs!(2, app!(
+        Var(1),
+        app(Var(2), abs!(2, Var(1))),
+        app(Var(2), abs!(2, Var(2)))
     ))
 }
 


### PR DESCRIPTION
Reducing a few of these functions that were not fully beta-reduced. Unfortunately this does sacrifice readability a bit.
  