### PR TITLE
add stumpfu::mul, signed::mul, fix signed docs

### DIFF
--- a/src/data/num/signed.rs
+++ b/src/data/num/signed.rs
@@ -113,7 +113,7 @@ pub fn simplify(encoding: Encoding) -> Term {
 ///
 /// # Example
 /// ```
-/// use lambda_calculus::data::num::signed::{to_signed, neg, modulus};
+/// use lambda_calculus::data::num::signed::modulus;
 /// use lambda_calculus::*;
 ///
 /// assert_eq!(beta(app(modulus(Church),    1.into_signed(Church)), NOR, 0), 1.into_church());
@@ -147,7 +147,7 @@ pub fn modulus(encoding: Encoding) -> Term {
 ///
 /// # Example
 /// ```
-/// use lambda_calculus::data::num::signed::{to_signed, neg, add};
+/// use lambda_calculus::data::num::signed::add;
 /// use lambda_calculus::*;
 ///
 /// assert_eq!(
@@ -190,7 +190,7 @@ pub fn add(encoding: Encoding) -> Term {
 ///
 /// # Example
 /// ```
-/// use lambda_calculus::data::num::signed::{to_signed, neg, sub};
+/// use lambda_calculus::data::num::signed::sub;
 /// use lambda_calculus::*;
 ///
 /// assert_eq!(
@@ -220,6 +220,75 @@ pub fn sub(encoding: Encoding) -> Term {
                 add(),
                 app(snd(), Var(2)),
                 app(fst(), Var(1))
+            )
+        )
+    ))
+}
+
+/// Applied to two signed integers with a specified encoding it returns a signed integer equal to
+/// their product.
+///
+/// MUL ≡ λa.λb.SIMPLIFY (PAIR (MUL (ADD (FST a) (FST b)) (ADD (SND a) (SND b)))
+/// (MUL (ADD (FST a) (SND b)) (ADD (SND a) (FST b)))) ≡
+/// λ λ SIMPLIFY (PAIR (MUL (ADD (FST 2) (FST 1)) (ADD (SND 2) (SND 1)))
+/// (MUL (ADD (FST 2) (SND 1)) (ADD (SND 2) (FST 1))))
+///
+/// # Example
+/// ```
+/// use lambda_calculus::data::num::signed::mul;
+/// use lambda_calculus::*;
+///
+/// assert_eq!(
+///     beta(app!(mul(Church), 2.into_signed(Church), (-3).into_signed(Church)), NOR, 0),
+///     beta((-6).into_signed(Church), NOR, 0)
+/// );
+/// ```
+pub fn mul(encoding: Encoding) -> Term {
+    let mul = || match encoding {
+        Church  => church::mul(),
+        Scott   => scott::mul(),
+        Parigot => parigot::mul(),
+        StumpFu => stumpfu::mul(),
+        Binary => panic!("signed binary numbers are not supported")
+    };
+
+    let add = || match encoding {
+        Church => church::add(),
+        Scott => scott::add(),
+        Parigot => parigot::add(),
+        StumpFu => stumpfu::add(),
+        Binary => panic!("signed binary numbers are not supported")
+    };
+
+    abs!(2, app(
+        simplify(encoding),
+        app!(
+            pair(),
+            app!(
+                add(),
+                app!(
+                    mul(),
+                    app(fst(), Var(2)),
+                    app(fst(), Var(1))
+                ),
+                app!(
+                    mul(),
+                    app(snd(), Var(2)),
+                    app(snd(), Var(1))
+                )
+            ),
+            app!(
+                add(),
+                app!(
+                    mul(),
+                    app(fst(), Var(2)),
+                    app(snd(), Var(1))
+                ),
+                app!(
+                    mul(),
+                    app(snd(), Var(2)),
+                    app(fst(), Var(1))
+                )
             )
         )
     ))

--- a/src/data/num/stumpfu.rs
+++ b/src/data/num/stumpfu.rs
@@ -104,3 +104,27 @@ pub fn add() -> Term {
         Var(1)
     ))
 }
+
+/// Applied to two Stump-Fu-encoded numbers it produces their product.
+///
+/// MUL ≡ λnm.n (λcp.c (λx.ADD m x) ZERO) ZERO ≡ λ λ 2 (λ λ 2 (λ ADD 4 1) ZERO) ZERO
+///
+/// # Example
+/// ```
+/// use lambda_calculus::data::num::stumpfu::mul;
+/// use lambda_calculus::*;
+///
+/// assert_eq!(beta(app!(mul(), 1.into_stumpfu(), 2.into_stumpfu()), NOR, 0), 2.into_stumpfu());
+/// assert_eq!(beta(app!(mul(), 2.into_stumpfu(), 3.into_stumpfu()), NOR, 0), 6.into_stumpfu());
+/// ```
+pub fn mul() -> Term {
+    abs!(2, app!(
+        Var(2),
+        abs!(2, app!(
+            Var(2),
+            abs(app!(add(), Var(4), Var(1))),
+            zero()
+        )),
+        zero()
+    ))
+}

--- a/tests/num.rs
+++ b/tests/num.rs
@@ -129,7 +129,7 @@ test_num!(parigot, parigot_mul, into_parigot, mul,
     2, 1 => 2,
     3, 2 => 6
 );
-/*
+
 test_num!(stumpfu, stumpfu_mul, into_stumpfu, mul,
     0, 0 => 0,
     0, 1 => 0,
@@ -139,7 +139,7 @@ test_num!(stumpfu, stumpfu_mul, into_stumpfu, mul,
     2, 1 => 2,
     3, 2 => 6
 );
-*/
+
 test_num!(church, church_pow, into_church, pow,
     0, 0 => 1,
     0, 1 => 0,

--- a/tests/signed.rs
+++ b/tests/signed.rs
@@ -61,3 +61,19 @@ fn signed_sub() {
     assert_eq!(beta(app!(sub(Church), 4.into_signed(Church), (-5).into_signed(Church)), NOR, 0), 9.into_signed(Church));
     assert_eq!(beta(app!(sub(Church), 4.into_signed(Church), (-4).into_signed(Church)), NOR, 0), 8.into_signed(Church));
 }
+
+#[test]
+fn signed_mul() {
+    assert_eq!(beta(app!(mul(Church), 0.into_signed(Church), 0.into_signed(Church)), NOR, 0), 0.into_signed(Church));
+    assert_eq!(beta(app!(mul(Church), 1.into_signed(Church), 0.into_signed(Church)), NOR, 0), 0.into_signed(Church));
+    assert_eq!(beta(app!(mul(Church), 2.into_signed(Church), 0.into_signed(Church)), NOR, 0), 0.into_signed(Church));
+    assert_eq!(beta(app!(mul(Church), 0.into_signed(Church), (-1).into_signed(Church)), NOR, 0), 0.into_signed(Church));
+    assert_eq!(beta(app!(mul(Church), 0.into_signed(Church), (-2).into_signed(Church)), NOR, 0), 0.into_signed(Church));
+    assert_eq!(beta(app!(mul(Church), 1.into_signed(Church), 1.into_signed(Church)), NOR, 0), 1.into_signed(Church));
+    assert_eq!(beta(app!(mul(Church), 1.into_signed(Church), (-1).into_signed(Church)), NOR, 0), (-1).into_signed(Church));
+    assert_eq!(beta(app!(mul(Church), (-1).into_signed(Church), (-1).into_signed(Church)), NOR, 0), 1.into_signed(Church));
+    assert_eq!(beta(app!(mul(Church), (-2).into_signed(Church), (-1).into_signed(Church)), NOR, 0), 2.into_signed(Church));
+    assert_eq!(beta(app!(mul(Church), 2.into_signed(Church), 2.into_signed(Church)), NOR, 0), 4.into_signed(Church));
+    assert_eq!(beta(app!(mul(Church), 2.into_signed(Church), 3.into_signed(Church)), NOR, 0), 6.into_signed(Church));
+    assert_eq!(beta(app!(mul(Church), (-2).into_signed(Church), 3.into_signed(Church)), NOR, 0), (-6).into_signed(Church));
+}


### PR DESCRIPTION
I don't see a definition for multiplication in [the Stump/Fu paper](http://homepage.cs.uiowa.edu/~astump/papers/stump-fu-jfp-2016.pdf), which is odd because multiplication is mentioned in the abstract. I think this is the most straightforward implementation. 