### PR TITLE
Support anyhow crate

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,6 +7,8 @@ use self::Token::*;
 pub use crate::term::Notation::*;
 use crate::term::Term::*;
 use crate::term::{abs, app, Notation, Term};
+use std::error::Error;
+use std::fmt;
 
 /// An error returned by `parse()` when a parsing issue is encountered.
 #[derive(Debug, PartialEq, Eq)]
@@ -17,6 +19,26 @@ pub enum ParseError {
     InvalidExpression,
     /// syntax error; the expression is empty
     EmptyExpression,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ParseError::InvalidCharacter((idx, char)) => write!(
+                f,
+                "lexical error; the invalid character '{}' at {}",
+                char, idx
+            ),
+            ParseError::InvalidExpression => write!(f, "syntax error; the expression is invalid"),
+            ParseError::EmptyExpression => write!(f, "syntax error; the expression is empty"),
+        }
+    }
+}
+
+impl Error for ParseError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -24,11 +24,9 @@ pub enum ParseError {
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            ParseError::InvalidCharacter((idx, char)) => write!(
-                f,
-                "lexical error; invalid character '{}' at {}",
-                char, idx
-            ),
+            ParseError::InvalidCharacter((idx, char)) => {
+                write!(f, "lexical error; invalid character '{}' at {}", char, idx)
+            }
             ParseError::InvalidExpression => write!(f, "syntax error; the expression is invalid"),
             ParseError::EmptyExpression => write!(f, "syntax error; the expression is empty"),
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,7 +26,7 @@ impl fmt::Display for ParseError {
         match *self {
             ParseError::InvalidCharacter((idx, char)) => write!(
                 f,
-                "lexical error; the invalid character '{}' at {}",
+                "lexical error; invalid character '{}' at {}",
                 char, idx
             ),
             ParseError::InvalidExpression => write!(f, "syntax error; the expression is invalid"),

--- a/src/term.rs
+++ b/src/term.rs
@@ -5,6 +5,7 @@ pub use self::Term::*;
 use self::TermError::*;
 use std::borrow::Cow;
 use std::char::from_u32;
+use std::error::Error;
 use std::fmt;
 
 /// The character used to display lambda abstractions (a backslash).
@@ -59,6 +60,22 @@ pub enum TermError {
     NotAbs,
     /// the term is not an application
     NotApp,
+}
+
+impl fmt::Display for TermError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            TermError::NotVar => write!(f, "the term is not a variable",),
+            TermError::NotAbs => write!(f, "the term is not an abstraction"),
+            TermError::NotApp => write!(f, "the term is not an application"),
+        }
+    }
+}
+
+impl Error for TermError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
 }
 
 impl Term {

--- a/tests/parse_error.rs
+++ b/tests/parse_error.rs
@@ -1,0 +1,17 @@
+extern crate lambda_calculus as lambda;
+
+use lambda::{parser::parse, term::Notation::Classic};
+use std::error::Error;
+
+#[test]
+fn parse_error_question_mark_operator() {
+    match using_question_mark_operator() {
+        Result::Ok(_) => panic!("Should not be Ok"),
+        Result::Err(e) => assert_eq!(e.to_string(), "syntax error; the expression is empty"),
+    }
+}
+
+fn using_question_mark_operator() -> Result<(), Box<dyn Error>> {
+    parse("λλλ", Classic)?;
+    Ok(())
+}

--- a/tests/term_error.rs
+++ b/tests/term_error.rs
@@ -1,0 +1,17 @@
+extern crate lambda_calculus as lambda;
+
+use lambda::term::Term;
+use std::error::Error;
+
+#[test]
+fn term_error_question_mark_operator() {
+    match using_question_mark_operator() {
+        Result::Ok(_) => panic!("Should not be Ok"),
+        Result::Err(e) => assert_eq!(e.to_string(), "the term is not an abstraction"),
+    }
+}
+
+fn using_question_mark_operator() -> Result<(), Box<dyn Error>> {
+    Term::Var(0).unabs()?;
+    Ok(())
+}


### PR DESCRIPTION
Hi,

I want to use lambda_calculus and https://github.com/dtolnay/anyhow crates in my app and wrote the following codes:

```rs
fn main() -> anyhow::Result<()> {
    let mut expr = parse(&"(λm.λn.λs.λz. m s (n s z)) (λs.λz. z) (λs.λz. s z)", Classic)?;
    ...
}
```

But it causes the error:

```
error[E0277]: the trait bound `ParseError: std::error::Error` is not satisfied
 --> src/main.rs:4:89
  |
4 |     let mut expr = parse(&"(λm.λn.λs.λz. m s (n s z)) (λs.λz. z) (λs.λz. s z)", Classic)?;
  |                                                                                         ^ the trait `std::error::Error` is not implemented for `ParseError`
  |
  = help: the following other types implement trait `FromResidual<R>`:
            <Result<T, F> as FromResidual<Result<Infallible, E>>>
            <Result<T, F> as FromResidual<Yeet<E>>>
  = note: required for `anyhow::Error` to implement `From<ParseError>`
  = note: required for `Result<(), anyhow::Error>` to implement `FromResidual<Result<Infallible, ParseError>>`
```

This PR implements the `Error` trait for `ParseError` and allows it to be converted into `anyhow::Error` .

I don't feel the need to convert to `anyhow::Error` for the `TermError`, but I implemented it just in case.

Note that I'd better use the https://github.com/dtolnay/thiserror trait for this purpose, but this crate should not depend on other crates, so I didn't use it.
