### PR TITLE
[BUG] Fix convert_classic_tokens

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,6 +7,7 @@ use self::Token::*;
 pub use crate::term::Notation::*;
 use crate::term::Term::*;
 use crate::term::{abs, app, Notation, Term};
+use std::collections::VecDeque;
 use std::error::Error;
 use std::fmt;
 
@@ -138,12 +139,12 @@ pub fn tokenize_cla(input: &str) -> Result<Vec<CToken>, ParseError> {
 
 #[doc(hidden)]
 pub fn convert_classic_tokens(tokens: &[CToken]) -> Vec<Token> {
-    _convert_classic_tokens(tokens, &mut Vec::with_capacity(tokens.len()), &mut 0)
+    _convert_classic_tokens(tokens, &mut VecDeque::with_capacity(tokens.len()), &mut 0)
 }
 
 fn _convert_classic_tokens<'t>(
     tokens: &'t [CToken],
-    stack: &mut Vec<&'t str>,
+    stack: &mut VecDeque<&'t str>,
     pos: &mut usize,
 ) -> Vec<Token> {
     let mut output = Vec::with_capacity(tokens.len() - *pos);
@@ -153,7 +154,7 @@ fn _convert_classic_tokens<'t>(
         match *token {
             CLambda(ref name) => {
                 output.push(Lambda);
-                stack.push(name);
+                stack.push_back(name);
                 inner_stack_count += 1;
             }
             CLparen => {
@@ -171,7 +172,7 @@ fn _convert_classic_tokens<'t>(
                     output.push(Number(index + 1))
                 } else {
                     // a new free variable
-                    stack.insert(0, name);
+                    stack.push_front(name);
                     // index of the last element + 1
                     output.push(Number(stack.len()))
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -138,17 +138,11 @@ pub fn tokenize_cla(input: &str) -> Result<Vec<CToken>, ParseError> {
 
 #[doc(hidden)]
 pub fn convert_classic_tokens(tokens: &[CToken]) -> Vec<Token> {
-    _convert_classic_tokens(
-        tokens,
-        &mut Vec::with_capacity(tokens.len()),
-        &mut Vec::with_capacity(tokens.len()),
-        &mut 0,
-    )
+    _convert_classic_tokens(tokens, &mut Vec::with_capacity(tokens.len()), &mut 0)
 }
 
 fn _convert_classic_tokens<'t>(
     tokens: &'t [CToken],
-    free_vars: &mut Vec<&'t str>,
     stack: &mut Vec<&'t str>,
     pos: &mut usize,
 ) -> Vec<Token> {
@@ -165,12 +159,7 @@ fn _convert_classic_tokens<'t>(
             CLparen => {
                 output.push(Lparen);
                 *pos += 1;
-                output.append(&mut _convert_classic_tokens(
-                    tokens,
-                    free_vars,
-                    stack,
-                    pos,
-                ));
+                output.append(&mut _convert_classic_tokens(tokens, stack, pos));
             }
             CRparen => {
                 output.push(Rparen);
@@ -180,11 +169,11 @@ fn _convert_classic_tokens<'t>(
             CName(ref name) => {
                 if let Some(index) = stack.iter().rev().position(|t| t == name) {
                     output.push(Number(index + 1))
-                } else if let Some(index) = free_vars.iter().position(|t| t == name) {
-                    output.push(Number(stack.len() + index + 1))
                 } else {
-                    output.push(Number(stack.len() + free_vars.len() + 1));
-                    free_vars.push(name);
+                    // a new free variable
+                    stack.insert(0, name);
+                    // index of the last element + 1
+                    output.push(Number(stack.len()))
                 }
             }
         }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,0 +1,33 @@
+use lambda_calculus::{
+    parse,
+    parser::ParseError,
+    term::Notation::{Classic, DeBruijn},
+};
+
+#[test]
+fn parse_debruijn_and_classic() -> Result<(), ParseError> {
+    for (dbr, cla) in [
+        ("12", "a b"),
+        ("λλ21", "λs. λz. s z"),
+        (
+            "λ2134(λ3215(λ4321)3215)2134",
+            "λx. w x y z (λy. w x y z (λz. w x y z) w x y z) w x y z",
+        ),
+        (
+            // See: http://alexandria.tue.nl/repository/freearticles/597619.pdf
+            "λ2(λ421(5(λ4127)λ8))67",
+            // the free variable list is ..ywzfba
+            "λx. a (λt. b x t (f (λu. a u t z) λs. w)) w y",
+        ),
+        (
+            // apply `plus zero one` to `s` and `z`
+            "(λλλλ42(321))(λλ1)(λλ21)12",
+            "(λm.λn.λs.λz. m s (n s z)) (λs.λz. z) (λs.λz. s z) s z",
+        ),
+    ] {
+        let term_dbr = parse(dbr, DeBruijn)?;
+        let term_cla = parse(cla, Classic)?;
+        assert_eq!(term_dbr, term_cla);
+    }
+    Ok(())
+}

--- a/tests/reduction.rs
+++ b/tests/reduction.rs
@@ -1,6 +1,7 @@
 extern crate lambda_calculus as lambda;
 
 use lambda::combinators::{I, O};
+use lambda::parser::ParseError;
 use lambda::*;
 use std::thread;
 
@@ -46,6 +47,20 @@ fn reduction_cbv() {
     assert_eq!(expr, app(I(), I()));
     expr.reduce(CBV, 1);
     assert_eq!(expr, I());
+}
+
+#[test]
+fn reduction_zero_plus_one() -> Result<(), ParseError> {
+    let mut expr = parse(
+        "(λm.λn.λs.λz. m s (n s z)) (λs.λz. z) (λs.λz. s z) s z",
+        Classic,
+    )?;
+    expr.reduce(CBV, 2);
+    assert_eq!(expr, parse("(λλ(λλ1)2((λλ21)21))12", DeBruijn)?);
+    expr.reduce(CBV, 6);
+    assert_eq!(expr, parse("12", DeBruijn)?);
+    assert_eq!(expr.to_string(), "a b");
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
`"a b"`, the classical notation containing two free variables, should be converted to `"12"` in `DeBruijn` notation, but the current implementation converts it to `"11"`. This PR fixes the problem.

Note that `"(λa. a) (λa. a) a"` can be converted to `"(λ1)(λ1)2"`, but for simplicity of implementation, I convert it to `"(λ1)(λ1)3"`. This is because I'm simply counting the number of appearances, not the maximum depth of λ-abstraction.