### PR TITLE
`Term::is_isomorphic_to`: A function to determine if two term objects describe identical expressions.

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -434,30 +434,15 @@ impl Term {
     ///
     /// ```
     pub fn is_isomorphic_to(&self, other: &Term) -> bool {
-        match self {
-            Var(x) => {
-                if let Var(y) = other {
-                    x == y
-                } else {
-                    false
-                }
+        match (self, other) {
+            (Var(x), Var(y)) => x == y,
+            (Abs(p), Abs(q)) => p.is_isomorphic_to(q),
+            (App(p_boxed), App(q_boxed)) => {
+                let (ref fp, ref ap) = **p_boxed;
+                let (ref fq, ref aq) = **q_boxed;
+                fp.is_isomorphic_to(fq) && ap.is_isomorphic_to(aq)
             }
-            Abs(p) => {
-                if let Abs(q) = other {
-                    p.is_isomorphic_to(q)
-                } else {
-                    false
-                }
-            }
-            App(p_boxed) => {
-                if let App(q_boxed) = other {
-                    let (ref fp, ref ap) = **p_boxed;
-                    let (ref fq, ref aq) = **q_boxed;
-                    fp.is_isomorphic_to(fq) && ap.is_isomorphic_to(aq)
-                } else {
-                    false
-                }
-            }
+            _ => false,
         }
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -418,6 +418,48 @@ impl Term {
             }
         }
     }
+
+    /// Returns `true` if `self` is structurally isomorphic to `other`.
+    ///
+    /// # Example
+    /// ```
+    /// use lambda_calculus::*;
+    ///
+    /// let term1 = abs(Var(1)); // λ 1
+    /// let term2 = abs(Var(2)); // λ 2
+    /// let term3 = abs(Var(1)); // λ 1
+    ///
+    /// assert_eq!(term1.is_isomorphic_to(&term2), false);
+    /// assert_eq!(term1.is_isomorphic_to(&term3), true);
+    ///
+    /// ```
+    pub fn is_isomorphic_to(&self, other: &Term) -> bool {
+        match self {
+            Var(x) => {
+                if let Var(y) = other {
+                    x == y
+                } else {
+                    false
+                }
+            }
+            Abs(p) => {
+                if let Abs(q) = other {
+                    p.is_isomorphic_to(q)
+                } else {
+                    false
+                }
+            }
+            App(p_boxed) => {
+                if let App(q_boxed) = other {
+                    let (ref fp, ref ap) = **p_boxed;
+                    let (ref fq, ref aq) = **q_boxed;
+                    fp.is_isomorphic_to(fq) && ap.is_isomorphic_to(aq)
+                } else {
+                    false
+                }
+            }
+        }
+    }
 }
 
 /// Wraps a `Term` in an `Abs`traction. Consumes its argument.
@@ -676,5 +718,14 @@ mod tests {
             app!(abs!(5, Var(2)), abs!(9, Var(4)), abs!(7, Var(6))).max_depth(),
             9
         );
+    }
+
+    #[test]
+    fn is_isomorphic_to() {
+        assert!(abs(Var(1)).is_isomorphic_to(&abs(Var(1))));
+        assert!(!abs(Var(1)).is_isomorphic_to(&abs(Var(2))));
+        assert!(!app(abs(Var(1)), Var(1)).is_isomorphic_to(&app(abs(Var(1)), Var(2))));
+        assert!(app(abs(Var(1)), Var(1)).is_isomorphic_to(&app(abs(Var(1)), Var(1))));
+        assert!(!app(abs(Var(1)), Var(1)).is_isomorphic_to(&app(Var(2), abs(Var(1)))));
     }
 }


### PR DESCRIPTION
I've added a `Term::is_isomorphic_to(&self, other: Term&)`, which determines if `&self` and `other` are structurally equivalent, ie they have isomorphic ASTs.

I'm not sure if `is_isomorphic_to` is a particularly good name for this function. Something like `is_equivalent_to` might be an alternative, but may not necessarily be better: program equivalence is the task of determining if two programs have identical behavior and is famously undecidable. Whereas this function only checks that the two `Term`s are equivalent. I'm open to discussion over the name.

I have avoided an implementation of `Eq` as the equivalence check is quite expensive - O(n) in the size of the AST.