### PR TITLE
handle free variables correctly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub mod combinators;
 pub mod parser;
 pub mod reduction;
 
-pub use self::parser::parse;
+pub use self::parser::{parse, parse_with_context};
 pub use self::reduction::beta;
 pub use self::reduction::Order::*;
 pub use self::term::Notation::*;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,7 +8,6 @@ use crate::term::Context;
 pub use crate::term::Notation::*;
 use crate::term::Term::*;
 use crate::term::{abs, app, Notation, Term};
-use std::collections::VecDeque;
 use std::error::Error;
 use std::fmt;
 
@@ -149,14 +148,14 @@ pub fn tokenize_cla(input: &str) -> Result<Vec<CToken>, ParseError> {
 
 #[doc(hidden)]
 pub fn convert_classic_tokens(ctx: &Context, tokens: &[CToken]) -> Result<Vec<Token>, ParseError> {
-    let mut stack = VecDeque::with_capacity(tokens.len());
+    let mut stack = Vec::with_capacity(tokens.len());
     stack.extend(ctx.iter().rev());
     _convert_classic_tokens(tokens, &mut stack, &mut 0)
 }
 
 fn _convert_classic_tokens<'t>(
     tokens: &'t [CToken],
-    stack: &mut VecDeque<&'t str>,
+    stack: &mut Vec<&'t str>,
     pos: &mut usize,
 ) -> Result<Vec<Token>, ParseError> {
     let mut output = Vec::with_capacity(tokens.len() - *pos);
@@ -166,7 +165,7 @@ fn _convert_classic_tokens<'t>(
         match *token {
             CLambda(ref name) => {
                 output.push(Lambda);
-                stack.push_back(name);
+                stack.push(name);
                 inner_stack_count += 1;
             }
             CLparen => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -427,6 +427,26 @@ mod tests {
     }
 
     #[test]
+    fn parse_classic_with_undefined_variable_error() {
+        let ctx_with_y = Context::new(&["y"]);
+
+        // "x" is not defined in the empty context
+        assert_eq!(
+            parse_with_context(&Context::empty(), "x", Classic),
+            Err(UndefinedFreeVariable)
+        );
+
+        // "x" is not defined in this context either
+        assert_eq!(
+            parse_with_context(&ctx_with_y, "λz.x", Classic),
+            Err(UndefinedFreeVariable)
+        );
+
+        // "y" is defined, so this should be OK
+        assert!(parse_with_context(&ctx_with_y, "y", Classic).is_ok());
+    }
+
+    #[test]
     fn alternative_lambda_parsing() {
         assert_eq!(parse(r"\\\2(321)", DeBruijn), parse("λλλ2(321)", DeBruijn))
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -236,7 +236,7 @@ fn _get_ast(tokens: &[Token], pos: &mut usize) -> Result<Expression, ParseError>
 /// Attempts to parse the input `&str` as a lambda `Term` encoded in the given `Notation`.
 ///
 /// - lambdas can be represented either with the greek letter (λ) or a backslash (\\ -
-/// less aesthetic, but only one byte in size)
+///   less aesthetic, but only one byte in size)
 /// - the identifiers in `Classic` notation are `String`s of alphabetic Unicode characters
 /// - `Classic` notation ignores whitespaces where unambiguous
 /// - the indices in the `DeBruijn` notation start with 1 and are hexadecimal digits

--- a/src/reduction.rs
+++ b/src/reduction.rs
@@ -10,7 +10,7 @@ use std::{cmp, fmt, mem};
 ///
 /// - the `NOR`, `HNO`, `APP` and `HAP` orders reduce expressions to their normal form
 /// - the `APP` order will fail to fully reduce expressions containing terms without a normal form,
-/// e.g. the `Y` combinator (they will expand forever)
+///   e.g. the `Y` combinator (they will expand forever)
 /// - the `CBN` order reduces to weak head normal form
 /// - the `CBV` order reduces to weak normal form
 /// - the `HSP` order reduces to head normal form

--- a/src/term.rs
+++ b/src/term.rs
@@ -842,7 +842,6 @@ mod tests {
 
         // contains
         assert!(ctx.contains("b"));
-        assert!(ctx.contains(&"c".to_string()));
         assert!(!ctx.contains("d"));
 
         // iter

--- a/src/term.rs
+++ b/src/term.rs
@@ -690,7 +690,7 @@ fn base26_encode(mut n: u32) -> String {
 
 fn show_precedence_cla(
     ctx: &Context,
-    binder_names: &Vec<String>,
+    binder_names: &[String],
     term: &Term,
     context_precedence: usize,
     depth: u32,

--- a/src/term.rs
+++ b/src/term.rs
@@ -38,6 +38,100 @@ pub enum Notation {
     DeBruijn,
 }
 
+/// A context holding a list of names for classic notation printing.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Context(Vec<String>);
+
+impl Context {
+    /// Creates a new `Context` from a slice of string-like items.
+    ///
+    /// This is the primary, most flexible constructor. It accepts anything
+    /// that can be borrowed as a string slice, like `&[&str]` or `&[String]`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lambda_calculus::term::Context;
+    ///
+    /// // Create from an array of &str
+    /// let context1 = Context::new(&["a", "b", "c"]);
+    ///
+    /// // Create from a Vec<String>
+    /// let names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+    /// let context2 = Context::new(&names);
+    ///
+    /// assert_eq!(context1, context2);
+    /// ```
+    pub fn new<S: AsRef<str>>(namings: &[S]) -> Self {
+        let owned = namings.iter().map(|s| s.as_ref().to_string()).collect();
+        Context(owned)
+    }
+
+    /// Creates an empty context.
+    pub fn empty() -> Self {
+        vec![].into()
+    }
+
+    /// Returns an iterator over the names in the context, yielding `&str`.
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &str> {
+        self.0.iter().map(|s| s.as_str())
+    }
+
+    /// Returns the number of names in the context.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the context contains no names.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns `true` if the context contains a name equivalent to the given value.
+    ///
+    /// This method is generic over `AsRef<str>`, so it can be called with
+    /// a string slice (`&str`), a `String`, or other string-like types.
+    pub fn contains<S: AsRef<str>>(&self, name: S) -> bool {
+        self.iter().any(|item| item == name.as_ref())
+    }
+
+    /// Resolves a 1-based index to a free variable name from the context.
+    ///
+    /// The index is 1-based, where `1` refers to the first name defined in the context.
+    /// Returns `None` if the index is 0 or out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lambda_calculus::term::Context;
+    /// let ctx = Context::new(&["a", "b", "c"]);
+    ///
+    /// assert_eq!(ctx.resolve_free_var(1), Some("a"));
+    /// assert_eq!(ctx.resolve_free_var(3), Some("c"));
+    /// assert_eq!(ctx.resolve_free_var(0), None);
+    /// assert_eq!(ctx.resolve_free_var(4), None);
+    /// ```
+    pub fn resolve_free_var(&self, idx: usize) -> Option<&str> {
+        if idx == 0 {
+            None
+        } else {
+            self.0.get(idx - 1).map(|s| s.as_str())
+        }
+    }
+}
+
+impl<S: AsRef<str>> From<&[S]> for Context {
+    fn from(namings: &[S]) -> Self {
+        Self::new(namings)
+    }
+}
+
+impl From<Vec<String>> for Context {
+    fn from(namings: Vec<String>) -> Self {
+        Context(namings)
+    }
+}
+
 /// A lambda term that is either a variable with a De Bruijn index, an abstraction over a term or
 /// an applicaction of one term to another.
 #[derive(PartialEq, Clone, Hash, Eq)]
@@ -470,6 +564,41 @@ impl Term {
             }
         }
     }
+
+    /// Calculates the maximum index of any free variable in the term.
+    ///
+    /// The result corresponds to the number of names `Context` must supply to bind them all.
+    pub fn max_free_index(&self) -> usize {
+        self.max_free_index_helper(0)
+    }
+
+    fn max_free_index_helper(&self, depth: usize) -> usize {
+        match self {
+            Var(x) => x.saturating_sub(depth),
+            Abs(p) => p.max_free_index_helper(depth + 1),
+            App(p_boxed) => {
+                let (ref f, ref a) = **p_boxed;
+                f.max_free_index_helper(depth)
+                    .max(a.max_free_index_helper(depth))
+            }
+        }
+    }
+
+    /// Returns a helper struct that allows displaying the term with a given context.
+    ///
+    /// # Example
+    /// ```
+    /// use lambda_calculus::{*, term::Context};
+    ///
+    /// let term = abs(Var(2)); // λa.b
+    /// let ctx = Context::new(&["x"]); // Predefine "x" as a free variable
+    ///
+    /// // The context defines `Var(2)` as "x" instead of the default "b"
+    /// assert_eq!(term.with_context(&ctx).to_string(), "λa.x");
+    /// ```
+    pub fn with_context<'a>(&'a self, ctx: &'a Context) -> impl fmt::Display + 'a {
+        DisplayWithContext { term: self, ctx }
+    }
 }
 
 /// Wraps a `Term` in an `Abs`traction. Consumes its argument.
@@ -499,8 +628,50 @@ pub fn app(lhs: Term, rhs: Term) -> Term {
 
 impl fmt::Display for Term {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", show_precedence_cla(self, 0, self.max_depth(), 0))
+        let max_depth = self.max_depth();
+        let max_free_index = self.max_free_index();
+        let ctx = auto_generate_context(max_depth, max_free_index);
+        let binder_names = generate_binder_names(&ctx, self.max_depth());
+        write!(
+            f,
+            "{}",
+            show_precedence_cla(&ctx, &binder_names, self, 0, 0)
+        )
     }
+}
+
+/// A helper function to generate a default context for displaying a term.
+fn auto_generate_context(max_depth: u32, max_free_index: usize) -> Context {
+    let free_variables = (0..max_free_index)
+        .map(|i| base26_encode(max_depth + i as u32))
+        .collect::<Vec<_>>();
+    free_variables.into()
+}
+
+/// A helper struct for displaying a `Term` with an external `Context`.
+struct DisplayWithContext<'a> {
+    term: &'a Term,
+    ctx: &'a Context,
+}
+
+impl<'a> fmt::Display for DisplayWithContext<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let binder_names = generate_binder_names(self.ctx, self.term.max_depth());
+        write!(
+            f,
+            "{}",
+            show_precedence_cla(self.ctx, &binder_names, self.term, 0, 0)
+        )
+    }
+}
+
+/// Generates a list of fresh names for binders, avoiding clashes with the given context.
+fn generate_binder_names(ctx: &Context, number: u32) -> Vec<String> {
+    (0..)
+        .map(|i| base26_encode(i as u32))
+        .filter(|name| !ctx.contains(name))
+        .take(number as usize)
+        .collect()
 }
 
 fn base26_encode(mut n: u32) -> String {
@@ -518,29 +689,36 @@ fn base26_encode(mut n: u32) -> String {
 }
 
 fn show_precedence_cla(
+    ctx: &Context,
+    binder_names: &Vec<String>,
     term: &Term,
     context_precedence: usize,
-    max_depth: u32,
     depth: u32,
 ) -> String {
     match term {
         Var(0) => "undefined".to_owned(),
         Var(i) => {
             let i = *i as u32;
-            let ix = if i <= depth {
-                depth - i
+            if i <= depth {
+                binder_names
+                    .get((depth - i) as usize)
+                    .expect("[BUG] binder_names are insufficient")
+                    .to_owned()
             } else {
-                max_depth + i - depth - 1
-            };
-            base26_encode(ix)
+                let idx = (i - depth) as usize;
+                ctx.resolve_free_var(idx)
+                    .map_or(format!("<unknown{}>", idx), |s| s.to_owned())
+            }
         }
         Abs(ref t) => {
             let ret = {
                 format!(
                     "{}{}.{}",
                     LAMBDA,
-                    base26_encode(depth),
-                    show_precedence_cla(t, 0, max_depth, depth + 1)
+                    binder_names
+                        .get(depth as usize)
+                        .expect("[BUG] binder_names are insufficient"),
+                    show_precedence_cla(ctx, binder_names, t, 0, depth + 1)
                 )
             };
             parenthesize_if(&ret, context_precedence > 1).into()
@@ -549,8 +727,8 @@ fn show_precedence_cla(
             let (ref t1, ref t2) = **boxed;
             let ret = format!(
                 "{} {}",
-                show_precedence_cla(t1, 2, max_depth, depth),
-                show_precedence_cla(t2, 3, max_depth, depth)
+                show_precedence_cla(ctx, binder_names, t1, 2, depth),
+                show_precedence_cla(ctx, binder_names, t2, 3, depth)
             );
             parenthesize_if(&ret, context_precedence == 3).into()
         }

--- a/src/term.rs
+++ b/src/term.rs
@@ -763,7 +763,7 @@ fn show_precedence_dbr(term: &Term, context_precedence: usize) -> String {
     }
 }
 
-fn parenthesize_if(input: &str, condition: bool) -> Cow<str> {
+fn parenthesize_if(input: &str, condition: bool) -> Cow<'_, str> {
     if condition {
         format!("({})", input).into()
     } else {

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,32 +1,38 @@
 use lambda_calculus::{
     parse,
-    parser::ParseError,
-    term::Notation::{Classic, DeBruijn},
+    parser::{parse_with_context, ParseError},
+    term::{
+        Context,
+        Notation::{Classic, DeBruijn},
+    },
 };
 
 #[test]
 fn parse_debruijn_and_classic() -> Result<(), ParseError> {
-    for (dbr, cla) in [
-        ("12", "a b"),
-        ("λλ21", "λs. λz. s z"),
+    for (ctx, dbr, cla) in [
+        (Context::new(&["a", "b"]), "12", "a b"),
+        (Context::empty(), "λλ21", "λs. λz. s z"),
         (
+            Context::new(&["w", "y", "z"]),
             "λ2134(λ3215(λ4321)3215)2134",
             "λx. w x y z (λy. w x y z (λz. w x y z) w x y z) w x y z",
         ),
         (
+            Context::new(&["a", "b", "f", "z", "w", "y"]),
             // See: http://alexandria.tue.nl/repository/freearticles/597619.pdf
             "λ2(λ421(5(λ4127)λ8))67",
             // the free variable list is ..ywzfba
             "λx. a (λt. b x t (f (λu. a u t z) λs. w)) w y",
         ),
         (
+            Context::new(&["s", "z"]),
             // apply `plus zero one` to `s` and `z`
             "(λλλλ42(321))(λλ1)(λλ21)12",
             "(λm.λn.λs.λz. m s (n s z)) (λs.λz. z) (λs.λz. s z) s z",
         ),
     ] {
         let term_dbr = parse(dbr, DeBruijn)?;
-        let term_cla = parse(cla, Classic)?;
+        let term_cla = parse_with_context(&ctx, cla, Classic)?;
         assert_eq!(term_dbr, term_cla);
     }
     Ok(())

--- a/tests/reduction.rs
+++ b/tests/reduction.rs
@@ -1,7 +1,8 @@
 extern crate lambda_calculus as lambda;
 
 use lambda::combinators::{I, O};
-use lambda::parser::ParseError;
+use lambda::parser::{parse_with_context, ParseError};
+use lambda::term::Context;
 use lambda::*;
 use std::thread;
 
@@ -51,7 +52,9 @@ fn reduction_cbv() {
 
 #[test]
 fn reduction_zero_plus_one() -> Result<(), ParseError> {
-    let mut expr = parse(
+    let ctx = Context::new(&["s", "z"]);
+    let mut expr = parse_with_context(
+        &ctx,
         "(λm.λn.λs.λz. m s (n s z)) (λs.λz. z) (λs.λz. s z) s z",
         Classic,
     )?;
@@ -59,7 +62,7 @@ fn reduction_zero_plus_one() -> Result<(), ParseError> {
     assert_eq!(expr, parse("(λλ(λλ1)2((λλ21)21))12", DeBruijn)?);
     expr.reduce(CBV, 6);
     assert_eq!(expr, parse("12", DeBruijn)?);
-    assert_eq!(expr.to_string(), "a b");
+    assert_eq!(expr.with_context(&ctx).to_string(), "s z");
     Ok(())
 }
 


### PR DESCRIPTION
Our current implementation of Term doesn't have free variable names as it is only a De Bruijn index expression, which is not correct. Free variable names are critical for open terms.

The issue is demonstrated by the following test, where free variable names were lost completely:

https://github.com/ljedrz/lambda_calculus/blob/c961a869398c1710dde5a609ee41a94d3f71cd74/tests/reduction.rs#L62

This PR introduces a naming Context to give names to free variables, which is the same approach as the TAPL book.

## Notes

A key inspiration for this change is the original TAPL implementation, which uses a top-level syntax to define variables (see https://github.com/mspertus/TAPL/blob/main/untyped/test.f ). In that implementation, you first have to define a variable like `x` (using `x/;` ), which pushes `x` into the naming context. Then, you can use `x` as a free variable.

Since our implementation does not have such a top-level syntax, this PR introduces a Context type instead, which must be prepared manually by the user.
